### PR TITLE
Clean up unicorn configuration

### DIFF
--- a/src/conf/unicorn.rb
+++ b/src/conf/unicorn.rb
@@ -1,24 +1,9 @@
 APP_PATH = ENV.fetch("DDBJ_VALIDATOR_APP_ROOT_PATH") { "/usr/src/ddbj_validator/src" }
-SHARED_PATH = ENV.fetch("DDBJ_VALIDATOR_SHARED_PATH") { "/usr/src/ddbj_validator/shared" }
-
-unless File.exist?("#{SHARED_PATH}")
-  Dir.mkdir("#{SHARED_PATH}")
-end
-unless File.exist?("#{SHARED_PATH}/tmp/pids")
-  Dir.mkdir("#{SHARED_PATH}/tmp")
-  Dir.mkdir("#{SHARED_PATH}/tmp/pids")
-end
-unless File.exist?("#{SHARED_PATH}/log")
-  Dir.mkdir("#{SHARED_PATH}/log")
-end
 
 listen  ENV.fetch("DDBJ_VALIDATOR_APP_UNICORN_PORT") { 3000 }
 timeout 900
 working_directory "#{APP_PATH}"
-pid "#{SHARED_PATH}/tmp/pids/unicorn.pid"
 
-stderr_path       "#{SHARED_PATH}/log/unicorn_err.log"
-stdout_path       "#{SHARED_PATH}/log/unicorn.log"
 worker_processes  4
 preload_app       true
 


### PR DESCRIPTION
- pid is always 1. So do not need write out
- Logs to stdout. Better for `docker compose logs`
