### PR TITLE
Tweak Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ruby:2.5
 
-COPY src /usr/src/ddbj_validator/src
 WORKDIR /usr/src/ddbj_validator/src
 
+COPY src/Gemfile src/Gemfile.lock ./
 RUN bundle install
+COPY src ./
 
 EXPOSE 3000
 CMD ["bundle", "exec", "unicorn", "-c", "/usr/src/ddbj_validator/src/conf/unicorn.rb", "-E", "development"]


### PR DESCRIPTION
Copy only Gemfile.* before `bundle install` for reusing layer cache.
