### PR TITLE
Avoid warnings from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     container_name: ${DDBJ_VALIDATOR_APP_CONTAINER_NAME:-ddbj_validator_app}
@@ -64,5 +63,5 @@ services:
 
 networks:
   ddbj:
-    external:
-      name: ${DDBJ_NETWORK_NAME:-ddbj}
+    name: ${DDBJ_NETWORK_NAME:-ddbj}
+    external: true


### PR DESCRIPTION
> WARN[0000] /home/ursm/Repositories/github.com/ddbj/ddbj_validator/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
> WARN[0000] networks.ddbj: external.name is deprecated. Please set name and external: true
