### PR TITLE
Disable BS_R0041 (latlon_versus_country)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Setting of request timeout for PostgreSQL. 30 seconds unless otherwise specified
 Versions of BioSample attributes and package definition information. ,Currently, `1.4.0`, `1.4.1`, `1.5.0` can be specified.
 
 `DDBJ_VALIDATOR_APP_GOOGLE_API_KEY`  
-Google API key.  Without this specification, some rules using Google's data (e.g. [BS_R0041] GeocodingAPI for Latlon versus country) will be ignored, even if the value is wrong.
+(Deprecated) Previously used by [BS_R0041] (Latlon versus country) via the Google Geocoding API. The rule is now disabled and there is no plan to use Google Geocoding again; a future replacement will be built on an offline geographic dataset such as Natural Earth. See [VALIDATOR-284](https://ddbj-dev.atlassian.net/browse/VALIDATOR-284).
 
 `DDBJ_VALIDATOR_APP_EUTILS_API_KEY`  
 API key for NCBI E-utilities. Without this specification, some rules using NCBI data (e.g. [BP_R0014]PMC ID validity) will be ignored, even if the value is wrong. See https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -343,7 +343,10 @@ class BioSampleValidator < ValidatorBase
       end
 
       ### 複数属性の組合せの検証
-      latlon_versus_country("BS_R0041", sample_name, biosample_data["attributes"]["geo_loc_name"], biosample_data["attributes"]["lat_lon"], @google_api_key, line_num)
+      # BS_R0041 (latlon_versus_country) は Google Geocoding API の有償化により無効化
+      # Google Geocoding API を再利用する予定はない。Natural Earth 等のオフラインデータを使った自前実装に置き換え次第復活させる
+      # https://ddbj-dev.atlassian.net/browse/VALIDATOR-284
+      # latlon_versus_country("BS_R0041", sample_name, biosample_data["attributes"]["geo_loc_name"], biosample_data["attributes"]["lat_lon"], @google_api_key, line_num)
       redundant_taxonomy_attributes("BS_R0073", sample_name, biosample_data["attributes"]["organism"], biosample_data["attributes"]["host"], biosample_data["attributes"]["isolation_source"], line_num)
 
       ### 値が複数記述される可能性がある項目を含む複数属性の組合せの検証

--- a/test/lib/validator/common/test_common_utils.rb
+++ b/test/lib/validator/common/test_common_utils.rb
@@ -142,16 +142,17 @@ class TestCommonUtils < Minitest::Test
     assert_nil ret
   end
 
-  def test_geocode_country_from_latlon 
+  def test_geocode_country_from_latlon
+    skip 'Google Geocoding API 無効化のため未使用 (VALIDATOR-284)'
     #ok case
     ret = @common.geocode_country_from_latlon("35.2095, 139.0034")
     assert_equal ["Japan"], ret
 
-    #no hit case 
+    #no hit case
     ret = @common.geocode_country_from_latlon("not valid latlon format")
     assert_nil ret
- 
-    #nil case 
+
+    #nil case
     ret = @common.geocode_country_from_latlon(nil)
     assert_nil ret
   end

--- a/test/lib/validator/common/test_save_auto_annotation.rb
+++ b/test/lib/validator/common/test_save_auto_annotation.rb
@@ -65,6 +65,7 @@ class TestSaveAutoAnnotation < Minitest::Test
   # 94(format_of_geo_loc_name_is_invalid)のauto annotationの保存が効いているかの検証
   # auto-annotated "  Jaaaapan: Hikone-shi" => "Jaaaapan: Hikone-shi"
   def test_save_annotation_94
+    skip 'BS_R0041 を経由した間接検証のため BS_R0041 停止中は動作不可 (VALIDATOR-284)'
     biosample_set = @validator.validate("#{@test_file_dir}/save_auto_annotation_value_94.xml")
     error_list = @validator.instance_variable_get (:@error_list)
     error =  error_list.find {|error| error[:id] == "BS_R0041"}
@@ -76,6 +77,7 @@ class TestSaveAutoAnnotation < Minitest::Test
   # 9(invalid_lat_lon_format)のauto annotationの保存が効いているかの検証
   # auto-annotated "37°26′36.42″N 06°15′14.28″W" => "37.4435 N 6.254 W"
   def test_save_annotation_9
+    skip 'BS_R0041 を経由した間接検証のため BS_R0041 停止中は動作不可 (VALIDATOR-284)'
     biosample_set = @validator.validate("#{@test_file_dir}/save_auto_annotation_value_9.xml")
     error_list = @validator.instance_variable_get (:@error_list)
     error =  error_list.find {|error| error[:id] == "BS_R0041"}

--- a/test/lib/validator/common/test_validator_cache.rb
+++ b/test/lib/validator/common/test_validator_cache.rb
@@ -60,6 +60,7 @@ class TestValidatorCache < Minitest::Test
   end
 
   def test_cache_latlon_versus_country
+    skip 'BS_R0041 は Google Geocoding API 無効化のため呼び出しを停止中 (VALIDATOR-284)'
     lat_lon = "35.2399 N, 139.0306 E"
     ret1 = @validator.send("latlon_versus_country", "BS_R0041", "SampleA", "Japan", lat_lon, 1)
     cache = @validator.instance_variable_get (:@cache)

--- a/test/lib/validator/test_biosample_validator.rb
+++ b/test/lib/validator/test_biosample_validator.rb
@@ -884,6 +884,7 @@ class TestBioSampleValidator < Minitest::Test
   end
 
   def test_latlon_versus_country
+    skip 'BS_R0041 は Google Geocoding API 無効化のため呼び出しを停止中 (VALIDATOR-284)'
     #ok case
     ret = exec_validator("latlon_versus_country", "BS_R0041", "SampleA", "Japan", "35.2399 N, 139.0306 E", nil, 1)
     assert_equal true, ret[:result]


### PR DESCRIPTION
## Summary
- BS_R0041 (lat_lon ↔ geo_loc_name の一致チェック) は Google Geocoding API の有償化+プロジェクト側の課金事情で現在使用不能になり、全サンプルに対して false-positive の警告が出続けていたため一旦無効化します
- Google Geocoding を再利用する予定はありません。将来的に Natural Earth 等のオフライン地理データを使った自前実装への置き換えを想定しています
- ルール定義および `geocode_country_from_latlon` / `latlon_versus_country` メソッド本体は deadcode として残し、復活時の差分を最小化します
- 関連テスト(BS_R0041 を直接/間接に叩くもの)は `skip` に変更しました

See [VALIDATOR-284](https://ddbj-dev.atlassian.net/browse/VALIDATOR-284).

## Test plan
- [ ] `rake test` で BS_R0041 関連テストが skip として扱われ、他のテストが pass することを確認
- [ ] geo_loc_name と lat_lon を含む BioSample を検証して、BS_R0041 の警告(`Geographic location is not retrieved by geocoding '...'`)が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)