### PR TITLE
Stub external HTTP in tests with WebMock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,5 @@ end
 
 group :test do
   gem 'minitest'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,9 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
     bigdecimal (3.2.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     csv (3.3.5)
     date (3.4.1)
@@ -21,6 +24,7 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    hashdiff (1.2.1)
     json-schema (5.2.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
@@ -71,6 +75,7 @@ GEM
       rack (>= 3.0.0)
     raindrops (0.20.1)
     rake (13.4.2)
+    rexml (3.4.4)
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -106,6 +111,10 @@ GEM
     unicorn-worker-killer (0.4.5)
       get_process_mem (~> 0)
       unicorn (>= 4, < 7)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin
@@ -133,6 +142,7 @@ DEPENDENCIES
   sinatra-reloader
   unicorn
   unicorn-worker-killer
+  webmock
 
 BUNDLED WITH
   4.0.10

--- a/test/lib/validator/bioproject_validator_test.rb
+++ b/test/lib/validator/bioproject_validator_test.rb
@@ -176,7 +176,6 @@ class TestBioProjectValidator < Minitest::Test
 
   # rule:BP_R0014
   def test_invalid_publication_identifier
-    skip_unless_eutils_api_key_configured
     #ok case
     ## valid PubMed id
     project_set = get_project_set_node("#{@test_file_dir}/14_invalid_publication_identifier_ok.xml")

--- a/test/lib/validator/trad_validator_test.rb
+++ b/test/lib/validator/trad_validator_test.rb
@@ -456,7 +456,6 @@ class TestTradValidator < Minitest::Test
   end
 
   def test_ddbj_parser
-    skip_unless_ddbj_parser_configured
     # TODO 正常系テスト
     # invalid file path
     params = {anno_file_path: "not_exist_ann_file", fasta_file_path: "not_exist_fasta_file", result_file_path: "not_exist_output_file"}

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,4 +1,6 @@
-# 外部サービス (PostgreSQL / Virtuoso) が利用できない環境 (CI 等) でテストをスキップするヘルパ
+# 外部サービス (PostgreSQL / Virtuoso) が利用できない環境 (CI 等) でテストをスキップするヘルパと、
+# テスト中にプロダクションコードから発生する外部 HTTP リクエスト (NCBI eutils / tm.dbcls.jp /
+# DDBJ parser) を stub するセットアップを提供する。
 #
 # 使い方:
 #   class TestFoo < Minitest::Test
@@ -21,9 +23,57 @@
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'bundler/setup'
+require 'json'
 require 'minitest/autorun'
 require 'net/http'
 require 'uri'
+require 'webmock/minitest'
+
+# localhost (Virtuoso / Postgres) だけ許可して、それ以外の外部 HTTP は全て stub 経由に縛る
+# テスト中の「うっかり本物の外部 API を叩く」を防ぐための基本姿勢
+WebMock.disable_net_connect!(allow_localhost: true)
+
+# test_ddbj_parser がエンドポイント設定済みの状態を前提にしているので、未設定なら stub URL を差し込む
+ENV['DDBJ_PARSER_APP_URL'] = 'http://ddbj-parser.stub/validate' if ENV['DDBJ_PARSER_APP_URL'].to_s.strip.empty?
+
+# webmock/minitest は各テスト完了後に stub を reset するので、default stub を
+# 個別 setup 前に都度貼り直すモジュールを Minitest::Test に挟み込む
+module DefaultHttpStubs
+  def before_setup
+    super
+
+    # DBCLS TM medline: デフォルトは「該当 PubMed ID なし」(空 MedlineCitationSet を返す)
+    WebMock.stub_request(:get, %r{\Ahttp://tm\.dbcls\.jp/medline/\d+\.json\z})
+      .to_return(status: 200, body: '{"MedlineCitationSet":{}}')
+
+    # 既知の「存在する」PubMed ID (テスト群が fixture で参照する値)
+    %w[1 15 12345 16088826 27148491].each do |id|
+      WebMock.stub_request(:get, "http://tm.dbcls.jp/medline/#{id}.json")
+        .to_return(status: 200, body: JSON.generate('MedlineCitationSet' => {'MedlineCitation' => {'PMID' => id}}))
+    end
+
+    # NCBI eutils esummary: デフォルトは「該当 ID なし」
+    WebMock.stub_request(:get, %r{\Ahttps://eutils\.ncbi\.nlm\.nih\.gov/entrez/eutils/esummary\.fcgi})
+      .to_return(status: 200, body: '{"result":{}}')
+
+    # 既知の「存在する」PMC ID
+    WebMock.stub_request(:get, %r{\Ahttps://eutils\.ncbi\.nlm\.nih\.gov/entrez/eutils/esummary\.fcgi.*[?&]id=5343844(?:&|\z)})
+      .to_return(status: 200, body: JSON.generate('result' => {'5343844' => {'uid' => '5343844'}}))
+
+    # DDBJ parser: 正常系ダミーレスポンスが必要なテストは個別に override 想定。
+    # デフォルトは 4xx を返して、ddbj_parser メソッド側の rescue が "Parse error" を raise する挙動を維持
+    # (ddbj_parser は GET リクエストを使う)
+    WebMock.stub_request(:get, %r{\Ahttp://ddbj-parser\.stub/})
+      .to_return(status: 400, body: 'stub: invalid request')
+
+    # test_ddbj_parser は "invalid host" ケースとして http://hogehoge.com を渡し、
+    # ddbj_parser 側は 4xx を "Parse error: ... server not found" に変換するので、それを再現
+    WebMock.stub_request(:get, %r{\Ahttp://hogehoge\.com/})
+      .to_return(status: 404, body: 'stub: host not found')
+  end
+end
+
+Minitest::Test.include(DefaultHttpStubs)
 
 module ServiceAvailability
   PG_CONFIGURED = !ENV['DDBJ_VALIDATOR_APP_POSTGRES_HOST'].to_s.strip.empty?
@@ -47,15 +97,6 @@ module ServiceAvailability
 
   def skip_unless_virtuoso_available
     skip 'Virtuoso SPARQL endpoint not reachable' unless VIRTUOSO_REACHABLE
-  end
-
-  def skip_unless_ddbj_parser_configured
-    skip 'DDBJ parser not configured (set DDBJ_PARSER_APP_URL to enable)' if ENV['DDBJ_PARSER_APP_URL'].to_s.strip.empty?
-  end
-
-  def skip_unless_eutils_api_key_configured
-    key = ENV['DDBJ_VALIDATOR_APP_EUTILS_API_KEY'].to_s
-    skip 'NCBI E-utilities API key not configured' if key.empty? || key == 'your_api_key'
   end
 end
 


### PR DESCRIPTION
## Summary
テスト中にプロダクションコードから発生する外部 HTTP リクエスト (NCBI eutils / tm.dbcls.jp / DDBJ parser) を WebMock で stub 化。テストが外部サービスに依存しないようにする。

## Before

- PubMed ID 存在チェック → `http://tm.dbcls.jp/medline/<id>.json` に実アクセス
- PMC ID 存在チェック → `https://eutils.ncbi.nlm.nih.gov/...` に API key 付きで実アクセス  
- TRAD parser → `DDBJ_PARSER_APP_URL` に実アクセス
- これらが届かない CI では `skip_unless_*` で丸ごと skip していて、テストが本来の意図を果たしていなかった

## 変更

- `Gemfile` に `webmock` を追加 (test group)
- `test/test_helpers.rb`:
  - `WebMock.disable_net_connect!(allow_localhost: true)` でローカル (Virtuoso / Postgres) 以外の外部 HTTP を一律遮断
  - `DefaultHttpStubs` モジュールを `Minitest::Test#before_setup` に hook して、各テスト毎に default stub を登録 (webmock/minitest が teardown 毎に reset するため)
  - デフォルト stub: tm.dbcls.jp → "PubMed ID なし"、既知 ID (1 / 15 / 12345 / 16088826 / 27148491) は "あり" を返す
  - NCBI eutils esummary 同様、PMC 5343844 のみ "あり"
  - DDBJ parser: 未設定なら `http://ddbj-parser.stub/` に向け、stub で 4xx を返して validator の "Parse error" rescue 経路を再現。 `http://hogehoge.com` (test_ddbj_parser の invalid host ケース) も同様
- 不要になった `skip_unless_ddbj_parser_configured` / `skip_unless_eutils_api_key_configured` ヘルパと、それを使っていた 2 テストの skip を解除

## Result

```
322 runs, 2570 assertions, 0 failures, 0 errors, 1 skips
```

残り 1 skip は `test_save_annotation_4` (ネットワークではなく、BS_R0004/BS_R0096 連動の auto-annotation 実装の見直し待ち)。

## Notes

- VCR は導入していない。現状叩いている API は「存在判定」等のバイナリ応答がほとんどで、レスポンス構造を深く依存していないため WebMock だけで十分と判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)