### PR TITLE
Add rolling deploy scripts for staging/production

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deploy main HEAD to staging or production.
+#
+# Usage:
+#   bin/deploy staging
+#   bin/deploy production
+#   bin/deploy staging 1       # only instance 1 (canary)
+#
+# Runs `git fetch && git merge --ff-only origin/main` on the target server,
+# rebuilds the app image, and force-recreates the container — sequentially
+# across the two load-balanced instances so nginx never loses both at once.
+#
+# Requires password-less SSH to w3sabi@<host>.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") {staging|production} [1|2]" >&2
+  exit 64
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+
+env="$1"
+only="${2:-}"
+
+case "$env" in
+  staging)
+    host='w3sabi@a012'
+    base='/data1/w3sabi/DDBJValidator/ddbj_validator_staging'
+    ;;
+  production)
+    host='w3sabi@a011'
+    base='/data1/w3sabi/DDBJValidator/ddbj_validator_production'
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+case "$only" in
+  '')   instances=(1 2) ;;
+  1|2)  instances=("$only") ;;
+  *)    usage ;;
+esac
+
+echo "=== Deploying $env to $host (instances: ${instances[*]}) ==="
+
+for i in "${instances[@]}"; do
+  dir="${base}${i}"
+  echo
+  echo ">>> ${env}${i}"
+  ssh -o BatchMode=yes -t "$host" "cd '$dir' && git fetch --prune origin && git merge --ff-only origin/main && ./bin/deploy-remote.sh"
+  echo "<<< ${env}${i} up"
+done
+
+echo
+echo "=== Done ==="

--- a/bin/deploy-remote.sh
+++ b/bin/deploy-remote.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Run by bin/deploy inside an instance directory on the server.
+# Assumes the caller has already fast-forwarded to origin/main.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+instance="$(basename "$PWD")"
+
+log() { printf '[%s] %s\n' "$instance" "$*"; }
+
+# Per-instance overrides (container names, ports, …). Sourced so we can read
+# DDBJ_VALIDATOR_APP_CONTAINER_NAME / DDBJ_VALIDATOR_APP_PORT below.
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+
+log "HEAD $(git log -1 --format='%h %s')"
+
+# Always build. If nothing changed, podman's layer cache makes this cheap;
+# if Gemfile.lock moved, rebuilding is the only way to avoid Bundler::GemNotFound
+# at unicorn boot.
+log 'podman-compose build app'
+podman-compose build app
+
+# podman-compose 1.0.6 will silently keep the existing container (and old image
+# ID) on `up -d` if it thinks the service is already up. --force-recreate is
+# mandatory here.
+log 'podman-compose up -d --force-recreate app'
+podman-compose up -d --force-recreate app
+
+cname="${DDBJ_VALIDATOR_APP_CONTAINER_NAME:-ddbj_validator_app}"
+port="${DDBJ_VALIDATOR_APP_PORT:-}"
+
+# Wait for the container to stabilize in `running`.
+for _ in $(seq 1 30); do
+  status="$(podman inspect "$cname" --format '{{.State.Status}}' 2>/dev/null || echo not-found)"
+  [[ "$status" == running ]] && break
+  sleep 1
+done
+
+if [[ "$status" != running ]]; then
+  log "container is $status — dumping logs"
+  podman logs --tail 60 "$cname" 2>&1 || true
+  exit 1
+fi
+
+# If a port is configured, probe unicorn — anything that gives us an HTTP
+# status (even 404) proves the process came up; 000 means still booting.
+if [[ -n "$port" ]]; then
+  log "probing http://localhost:$port"
+  for _ in $(seq 1 30); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' -m 2 "http://localhost:$port/" || echo 000)"
+    [[ "$code" != 000 ]] && break
+    sleep 2
+  done
+  if [[ "$code" == 000 ]]; then
+    log 'app never opened the port — dumping logs'
+    podman logs --tail 60 "$cname" 2>&1 || true
+    exit 1
+  fi
+  log "HTTP $code"
+fi
+
+log 'deploy ok'


### PR DESCRIPTION
## Summary
- Replaces the manual \`ssh → git pull → podman-compose build → podman-compose up -d --force-recreate → check logs\` sequence with a single \`bin/deploy {staging|production}\` invocation from the local machine.
- Deploys the two load-balanced instances (\`*1\` then \`*2\`) sequentially so nginx always has one up.
- Always rebuilds, because podman-compose 1.0.6 has twice bitten us by keeping the stale image ID on \`up -d\` — \`--force-recreate\` is now mandatory inside the script.

## Usage
\`\`\`sh
./bin/deploy staging            # staging1 → staging2
./bin/deploy production         # production1 → production2
./bin/deploy staging 1          # canary (one instance only)
\`\`\`

Requires password-less SSH to \`w3sabi@a011\` / \`w3sabi@a012\` from whoever runs the script.

## Test plan
- [ ] Dry-run: \`./bin/deploy staging 1\` against staging1, confirm it fetches main, rebuilds, force-recreates, and the HTTP probe returns a non-000 code.
- [ ] Follow up with \`./bin/deploy staging 2\` and verify nginx kept serving throughout.
- [ ] Once staging is clean, merge and use it for the next production deploy.
- [ ] Argument parsing (already verified locally): missing args / bad env / instance 3 all reject with usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)