### PR TITLE
Replace deploy healthcheck loop with curl --retry against /api/monitoring

### DIFF
--- a/bin/deploy-remote.sh
+++ b/bin/deploy-remote.sh
@@ -48,21 +48,27 @@ if [[ "$status" != running ]]; then
   exit 1
 fi
 
-# If a port is configured, probe unicorn — anything that gives us an HTTP
-# status (even 404) proves the process came up; 000 means still booting.
+# Probe the monitoring endpoint, which runs a full biosample validation cycle
+# end-to-end — anything less than a 2xx means unicorn is up but something in
+# the pipeline is broken, which is the signal we want.
+#
+# --retry-all-errors retries on both transport errors (connect refused while
+#   unicorn is still booting, timeouts from the kgio/unicorn SEGV that slipped
+#   past the old probe) and HTTP 4xx/5xx when paired with --fail.
+# --retry-max-time bounds total wall-clock across retries; --max-time caps
+#   one attempt so a hung worker can't swallow the entire window.
 if [[ -n "$port" ]]; then
-  log "probing http://localhost:$port"
-  for _ in $(seq 1 30); do
-    code="$(curl -s -o /dev/null -w '%{http_code}' -m 2 "http://localhost:$port/" || echo 000)"
-    [[ "$code" != 000 ]] && break
-    sleep 2
-  done
-  if [[ "$code" == 000 ]]; then
-    log 'app never opened the port — dumping logs'
+  url="http://localhost:$port/api/monitoring"
+  log "probing $url"
+  if code=$(curl --fail --silent --output /dev/null --write-out '%{http_code}' \
+                --max-time 90 --retry 10 --retry-all-errors --retry-delay 2 --retry-max-time 180 \
+                "$url"); then
+    log "HTTP $code"
+  else
+    log 'monitoring probe failed — dumping logs'
     podman logs --tail 60 "$cname" 2>&1 || true
     exit 1
   fi
-  log "HTTP $code"
 fi
 
 log 'deploy ok'


### PR DESCRIPTION
## Summary
- Fixes the false-success bug that hid the Ruby 4.0 / kgio SEGV from the deploy script (PR #145).
- Simplifies the probe to a single \`curl\` invocation that uses \`--retry-all-errors\` for the bash-loop behavior we had been hand-rolling, and targets \`/api/monitoring\` (full biosample validation round-trip) instead of \`/\` (static 404).

## Root cause of the false success
The old probe was:

\`\`\`bash
code=\"\$(curl -s -o /dev/null -w '%{http_code}' -m 2 \"\$url\" || echo 000)\"
[[ \"\$code\" != 000 ]] && break
\`\`\`

\`curl -w '%{http_code}'\` writes \`000\` on every failed request (timeout, connection refused, …) and also exits non-zero. The \`|| echo 000\` branch appended a second \`000\`, so the captured value was \`000000\`. \`[[ \"000000\" != \"000\" ]]\` is true, so the loop broke on the first iteration and reported success.

\`\`\`sh
\$ port=1
\$ code=\"\$(curl -s -o /dev/null -w '%{http_code}' -m 1 \"http://localhost:\$port/\" || echo 000)\"
\$ echo \"[\$code] len=\${#code}\"
[000000] len=6
\$ [[ \"\$code\" != 000 ]] && echo \"thinks it's up\"
thinks it's up
\`\`\`

That is exactly what happened during the staging deploy: unicorn's listening socket accepted the TCP handshake, the worker SEGV'd on \`accept(2)\`, curl timed out, the script reported \`HTTP 000000\` as success.

## New probe

\`\`\`bash
curl --fail --silent --output /dev/null --write-out '%{http_code}' \\
     --max-time 90 --retry 10 --retry-all-errors --retry-delay 2 --retry-max-time 180 \\
     \"http://localhost:\$port/api/monitoring\"
\`\`\`

- \`/api/monitoring\` runs a full biosample validation cycle end-to-end (fetch sample XML → POST for validation → poll → verify result), so a 2xx here means the entire pipeline is functional.
- \`--retry-all-errors\` retries on transport errors (connect refused while unicorn is booting, timeouts from a crashed worker) and \`--fail\` promotes 4xx/5xx to retryable errors.
- \`--retry-max-time 180\` caps total wall-clock; \`--max-time 90\` caps any single attempt so a hung worker can't swallow the window.
- curl's exit status is now the single source of truth — no more \`|| echo 000\` trap.

## Test plan
- [x] Local reproduction of the old bug (\`[000000] len=6\`, \"thinks it's up\").
- [x] Local sanity check that the new form fails cleanly against an unused port (curl exits 7).
- [ ] After staging is back on Ruby 3.4 (PR #145), run \`bin/deploy staging\` and confirm the probe reports a real HTTP code.
- [ ] Intentionally break one staging instance (e.g., kill the app inside the container) and confirm the probe fails the deploy instead of silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)