### PR TITLE
Decouple tests from runtime-only conf/pub and conf/coll_dump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,13 +58,7 @@ jobs:
       - name: Load taxonomy / biosample fixture
         run: docker compose -f compose.test.yaml exec -T virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
 
-      # conf/pub と conf/coll_dump は本番で外部データをマウントするため .gitignore 済み。
-      # テスト用のスナップショットを test/fixtures/conf/ に置いてあるので所定の場所へ配置する
-      - name: Stage reference data (country list, coll_dump)
-        run: |
-          mkdir -p conf/pub conf/coll_dump
-          cp -r test/fixtures/conf/pub/.       conf/pub/
-          cp -r test/fixtures/conf/coll_dump/. conf/coll_dump/
-
       # -v で各テスト名を標準出力に流す。どのテストで詰まったかを CI ログから特定できるように
+      # pub / coll_dump は test/test_helpers.rb が env 経由で test/fixtures を指すので、
+      # ここで conf/pub にステージする必要はない
       - run: bundle exec ruby test/run_all.rb -v

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -72,15 +72,20 @@ class BioSampleValidator < ValidatorBase
       config[:ts_attr] = JSON.parse(File.read(config_file_dir + "/timestamp_attributes.json"))
       config[:int_attr] = JSON.parse(File.read(config_file_dir + "/integer_attributes.json"))
       config[:special_chars] = JSON.parse(File.read(config_file_dir + "/special_characters.json"))
-      config[:country_list] = JSON.parse(File.read(config_file_dir + "/../pub/docs/common/country_list.json"))
-      config[:historical_country_list] = JSON.parse(File.read(config_file_dir + "/../pub/docs/common/historical_country_list.json"))
+      # pub リポジトリ (github.com/ddbj/pub) と coll_dump は本番ではそれぞれ外部ディレクトリが
+      # conf/pub / conf/coll_dump にバインドマウントされる。テストで本物のマウントを用意する代わりに、
+      # env で test/fixtures/ 配下のスナップショットを指せるようにしておく
+      pub_dir        = ENV.fetch('DDBJ_VALIDATOR_APP_PUB_DIR')        { config_file_dir + '/../pub' }
+      coll_dump_file = ENV.fetch('DDBJ_VALIDATOR_APP_COLL_DUMP_FILE') { config_file_dir + '/../coll_dump/coll_dump.txt' }
+      config[:country_list] = JSON.parse(File.read(pub_dir + "/docs/common/country_list.json"))
+      config[:historical_country_list] = JSON.parse(File.read(pub_dir + "/docs/common/historical_country_list.json"))
       config[:valid_country_list] = config[:country_list] + config[:historical_country_list]
       config[:exchange_country_list] = JSON.parse(File.read(config_file_dir + "/exchange_country_list.json"))
       config[:convert_date_format] = JSON.parse(File.read(config_file_dir + "/convert_date_format.json"))
       config[:ddbj_date_format] = JSON.parse(File.read(config_file_dir + "/ddbj_date_format.json"))
       config[:invalid_strain_value] = JSON.parse(File.read(config_file_dir + "/invalid_strain_value.json"))
       config[:json_schema] = JSON.parse(File.read(config_file_dir + "/schema.json"))
-      config[:institution_list_file] = config_file_dir + "/../coll_dump/coll_dump.txt"
+      config[:institution_list_file] = coll_dump_file
       config[:google_api_key] = @conf[:google_api_key]
       config[:eutils_api_key] = @conf[:eutils_api_key]
       config

--- a/test/lib/validator/biosample_validator_test.rb
+++ b/test/lib/validator/biosample_validator_test.rb
@@ -512,8 +512,8 @@ class TestBioSampleValidator < Minitest::Test
   end
 
   def test_invalid_geo_loc_name_format
-    country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../../conf/pub/docs/common/country_list.json"))
-    historical_country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../../conf/pub/docs/common/historical_country_list.json"))
+    country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../fixtures/conf/pub/docs/common/country_list.json"))
+    historical_country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../fixtures/conf/pub/docs/common/historical_country_list.json"))
     valid_country_list = country_list + historical_country_list
     #ok case
     ret = exec_validator("invalid_geo_loc_name_format", "BS_R0094", "SampleA", "Japan:Kanagawa, Hakone, Lake Ashi", valid_country_list, 1)
@@ -581,8 +581,8 @@ class TestBioSampleValidator < Minitest::Test
   end
 
   def test_invalid_country
-    country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../../conf/pub/docs/common/country_list.json"))
-    historical_country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../../conf/pub/docs/common/historical_country_list.json"))
+    country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../fixtures/conf/pub/docs/common/country_list.json"))
+    historical_country_list = JSON.parse(File.read(File.dirname(__FILE__) + "/../../fixtures/conf/pub/docs/common/historical_country_list.json"))
     country_list = country_list + historical_country_list
     #ok case
     ret = exec_validator("invalid_country", "BS_R0008", "sampleA", "Japan:Kanagawa, Hakone, Lake Ashi", country_list, 1)
@@ -2019,7 +2019,7 @@ jkl\"  "
   end
 
   def test_invalid_culture_collection
-    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../../conf/coll_dump/coll_dump.txt")
+    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../fixtures/conf/coll_dump/coll_dump.txt")
     # ok case
     ret = exec_validator("invalid_culture_collection", "BS_R0114", "SampleA", "ATCC:1234", institution_list, 5, 1)
     assert_equal true, ret[:result]
@@ -2096,7 +2096,7 @@ jkl\"  "
   end
 
   def test_invalid_specimen_voucher
-    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../../conf/coll_dump/coll_dump.txt")
+    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../fixtures/conf/coll_dump/coll_dump.txt")
     # ok case
     ret = exec_validator("invalid_specimen_voucher", "BS_R0117", "SampleA", "UAM:12345", institution_list, 5, 1)
     assert_equal true, ret[:result]
@@ -2145,7 +2145,7 @@ jkl\"  "
   end
 
   def test_invalid_bio_material
-    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../../conf/coll_dump/coll_dump.txt")
+    institution_list = CommonUtils.new.parse_coll_dump(File.dirname(__FILE__) + "/../../fixtures/conf/coll_dump/coll_dump.txt")
     # ok case
     ret = exec_validator("invalid_bio_material", "BS_R0119", "SampleA", "ABRC:CS22676", institution_list, 1)
     assert_equal true, ret[:result]

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -36,6 +36,11 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # test_ddbj_parser がエンドポイント設定済みの状態を前提にしているので、未設定なら stub URL を差し込む
 ENV['DDBJ_PARSER_APP_URL'] = 'http://ddbj-parser.stub/validate' if ENV['DDBJ_PARSER_APP_URL'].to_s.strip.empty?
 
+# BioSampleValidator#read_config が参照する INSDC 国名リスト / coll_dump を
+# test/fixtures 配下のスナップショットに向ける。本番は .env で別ディレクトリを指すので影響なし
+ENV['DDBJ_VALIDATOR_APP_PUB_DIR']        ||= File.expand_path('fixtures/conf/pub',                   __dir__)
+ENV['DDBJ_VALIDATOR_APP_COLL_DUMP_FILE'] ||= File.expand_path('fixtures/conf/coll_dump/coll_dump.txt', __dir__)
+
 # webmock/minitest は各テスト完了後に stub を reset するので、default stub を
 # 個別 setup 前に都度貼り直すモジュールを Minitest::Test に挟み込む
 module DefaultHttpStubs


### PR DESCRIPTION
## Summary
Tests no longer expect the runtime-only \`conf/pub\` / \`conf/coll_dump\` directories to be populated on disk. They read snapshots directly from \`test/fixtures/conf/\` instead, which removes the confusing CI copy step and makes the test suite self-contained.

## Why
Per VALIDATOR-280 (closed), \`conf/pub\` is meant to be a bind-mount target populated from \`github.com/ddbj/pub\` on staging/production (via a shared disk with a manual \`git pull\`); the in-repo directory is only \`.gitignore\`d scratch space. Having tests read from there forced CI to copy fixtures into \`conf/pub\` before every run, which blurred the line between \"runtime data\" and \"committed test fixtures\" — the exact confusion Keita flagged in the VALIDATOR-280 Slack thread.

## Changes
- \`lib/validator/biosample_validator.rb\`: \`read_config\` honors two optional env vars, falling back to the existing \`conf/pub\` / \`conf/coll_dump\` paths when unset (no production behavior change):
  - \`DDBJ_VALIDATOR_APP_PUB_DIR\` — directory containing \`docs/common/country_list.json\` etc.
  - \`DDBJ_VALIDATOR_APP_COLL_DUMP_FILE\` — full path to \`coll_dump.txt\`.
- \`test/test_helpers.rb\`: sets those env vars to the snapshots under \`test/fixtures/conf/\`, so every test class that loads the helper gets the right data without further plumbing.
- \`test/lib/validator/biosample_validator_test.rb\`: three direct \`File.read\` / \`parse_coll_dump\` call sites now reference \`test/fixtures/conf/\` instead of the runtime paths.
- \`.github/workflows/test.yml\`: the \"Stage reference data\" step is gone.

## Test plan
- [x] Ran \`bundle exec ruby test/run_all.rb\` with \`conf/pub\` and \`conf/coll_dump\` renamed out of the way (so the only way the validator could find country_list.json was via the new env var). Result: 324 runs / 2600 assertions / 0 failures / 0 errors / 1 pre-existing skip.
- [ ] CI rerun will confirm the same without the copy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)