### PR TITLE
Fix /api/monitoring: Rack 3 compat + 503 on NG

### DIFF
--- a/app/application.rb
+++ b/app/application.rb
@@ -316,6 +316,10 @@ module DDBJValidator
       rescue => e
         ret_message = '{"status": "NG", "message": "Error has occurred during monitoring processing. Please check the validation service. ' + e.message + '"}'
       end
+      # NG のときは HTTP レベルでも不健全を表す。200 で返すと deploy の curl --fail probe や
+      # 外形監視ツールがサービス正常と判断してしまうため
+      content_type :json
+      status 503 unless ret_message.start_with?('{"status": "OK"')
       ret_message
     end
 
@@ -466,9 +470,14 @@ module DDBJValidator
     helpers do
       # file数と組み合わせをチェック
       def valid_file_combination?
-        # paramsでは重複を省いたrequest parameterで渡されるため、form_inputで全データ確認する
+        # paramsでは重複を省いたrequest parameterで渡されるため、form_inputで全データ確認する。
+        # Rack 3 で rack.request.form_input は multipart 時でも nil になり得るので、常に生 body
+        # を保持する rack.input から読む。他のミドルウェアが先に読んでいる場合に備えて rewind する
         file_combination = true
-        form_vars = @env["rack.request.form_input"].read
+        input = @env["rack.input"]
+        input.rewind if input.respond_to?(:rewind)
+        form_vars = input.read
+        input.rewind if input.respond_to?(:rewind)
         form_vars = Rack::Utils.escape(form_vars)
         req_params = Rack::Utils.parse_query(form_vars)
         param_names = req_params["name"]


### PR DESCRIPTION
## Summary
Staging's \`/api/monitoring\` has been returning \`HTTP 200 {\"status\": \"NG\", \"message\": \"...unexpected token at '<!DOCTYPE html>...\"}\`. Two linked bugs:

### 1. \`valid_file_combination?\` crashes under Rack 3
\`\`\`
NoMethodError - undefined method 'read' for nil:
  form_vars = @env[\"rack.request.form_input\"].read
  app/application.rb:471:in 'DDBJValidator::Application#valid_file_combination?'
  app/application.rb:55:in 'block in <class:Application>'  # POST /api/validation
\`\`\`

Rack 3 no longer guarantees \`rack.request.form_input\` is populated for multipart POSTs. Switch to \`@env[\"rack.input\"]\` (the raw body IO, present on every Rack version) and rewind around the read since middleware may already have consumed it.

Note: the helper's \`Rack::Utils.escape(raw_body) → Rack::Utils.parse_query\` flow URL-encodes the multipart boundary wholesale (both \`=\` and \`&\` get escaped), so \`req_params[\"name\"]\` was effectively always nil on Rack 2 as well — the helper has been a no-op returning \`true\` for the entire life of this code. This commit keeps that behavior while stopping the crash. Rewriting the helper to actually parse multipart is follow-up work (tracked separately).

### 2. \`/api/monitoring\` returns 200 even on NG
Because of (1) the monitoring flow goes: POST \`/api/validation\` → crash → Sinatra emits the HTML ShowExceptions page → monitoring's \`JSON.parse(res.body)\` throws → rescue returns \`{\"status\":\"NG\", …}\` with HTTP 200.

External monitors (including our own \`bin/deploy-remote.sh\` \`curl --fail\` probe) see 200 and call the instance healthy. Return HTTP 503 when the JSON status isn't \`\"OK\"\` so the HTTP layer tells the truth.

## Test plan
- [x] \`ruby -c app/application.rb\` clean.
- [x] \`bundle exec ruby test/run_all.rb\` unchanged — 324 runs / 2600 assertions / 0 failures.
- [ ] After merge + deploy: \`curl -sS -o /dev/null -w \"%{http_code}\\n\" https://ddbj-staging.nig.ac.jp/api/monitoring\` should return \`200\` once the underlying validation pipeline is working, or \`503\` if it isn't.
- [ ] Same probe from \`bin/deploy-remote.sh\` should now fail the deploy if the monitoring endpoint says NG, instead of silently declaring the instance healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)