### PR TITLE
Slim the production image: dockerignore + bundle without dev/test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,58 @@
-.dockerignore
-docker-compose.yml
-Dockerfile
-README.md
-shared/config/entrypoint.virtuoso.sh
-shared/config/virtuoso
-shared/data/virtuoso
+# Git metadata
+.git
+.github
+.gitignore
+.gitmodules
+
+# OS / editor / dev-tool junk
+.DS_Store
+*.swp
+*.swo
+.idea
+*.iml
+.mise.toml
+.ruby-lsp
+.memsearch
+Procfile.dev
+
+# Local env / secrets
+.env
 template.env
+
+# Docker build inputs aren't needed inside the final image
+.dockerignore
+Dockerfile
+docker-compose.yml
+compose.*.yaml
+
+# Dev-only docs
+README.md
+
+# Tests and their fixtures — production has no reason to ship Virtuoso
+# dumps, Postgres seeds, or the committed snapshots of ddbj/pub.
+test
+
+# Runtime bind-mount targets. Whatever is in the image at these paths is
+# masked by the compose volumes in staging/production, so shipping them
+# just bloats the image.
+conf/pub
+conf/coll_dump
+shared
+logs
+log
+
+# Separate sub-apps / tools not used by the validator runtime. Each has
+# its own Dockerfile or runs from the host.
+data_updater
+log_analysis
+
+# Ops scripts that run on the host, not inside the container.
+bin/deploy
+bin/deploy-remote.sh
+bin/deploy_tools
 deploy_tools
 monitoring
-logs
+
+# Scratch
+tmp
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM ruby:3.4.9
 WORKDIR /usr/src/ddbj_validator/
 
 COPY ./Gemfile ./Gemfile.lock ./
-RUN bundle install
+# Skip dev/test groups in the production image so rake/minitest/webmock and
+# friends don't ship to servers. The config is written to .bundle/config and
+# persists for subsequent `bundle exec` invocations in this image.
+RUN bundle config set --local without 'development test' && bundle install
 COPY ./ ./
 
 EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "sinatra-contrib"
 
 group :development do
   gem 'rake'
-  gem 'sinatra-reloader'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,8 +96,6 @@ GEM
       rack-protection (= 4.2.1)
       sinatra (= 4.2.1)
       tilt (~> 2.0)
-    sinatra-reloader (1.0)
-      sinatra-contrib
     temple (0.10.3)
     thor (1.3.2)
     tilt (2.7.0)
@@ -133,7 +131,6 @@ DEPENDENCIES
   sanitize
   sinatra
   sinatra-contrib
-  sinatra-reloader
   webmock
 
 BUNDLED WITH

--- a/app/application.rb
+++ b/app/application.rb
@@ -2,7 +2,6 @@ require 'yaml'
 require 'sinatra/base'
 require 'sinatra/json'
 require "securerandom"
-require 'sinatra/reloader'
 require 'net/http'
 require 'net/https'
 require 'fileutils'


### PR DESCRIPTION
## Summary
Two things were putting noise into the production image:

1. \`bundle install\` was installing every gem group, including \`development\` (rake, sinatra-reloader) and \`test\` (minitest, webmock). Configure \`bundle config --local without 'development test'\` before installing.
2. \`.dockerignore\` was very small. \`COPY ./ ./\` was sweeping in \`conf/pub/\` (188 MB — the developer's local ddbj/pub git clone), \`.git/\` (120 MB), \`test/\` fixtures, \`data_updater/\`, \`log_analysis/\`, and a handful of dev-tool files (\`.mise.toml\`, \`.ruby-lsp/\`, \`Procfile.dev\`). The bind-mount targets (\`conf/pub\`, \`conf/coll_dump\`, \`shared\`, \`logs\`) would get masked by compose volumes at runtime anyway.

Also removed \`require 'sinatra/reloader'\` from \`app/application.rb\` — it was never followed by \`register Sinatra::Reloader\`, so it was dead code. Dropping the require let us drop the sinatra-reloader gem from the Gemfile entirely.

## Changes

- \`Dockerfile\`: \`RUN bundle config set --local without 'development test' && bundle install\`.
- \`.dockerignore\`: rewritten and grouped by category (git metadata, OS/editor junk, env/secrets, Docker build inputs, tests, runtime bind-mount targets, sub-apps, ops scripts, scratch).
- \`Gemfile\` / \`Gemfile.lock\`: remove \`sinatra-reloader\`.
- \`app/application.rb\`: drop the unused \`require 'sinatra/reloader'\`.

## Test plan

- [x] \`bundle install\` clean under Ruby 3.4.9; \`Gemfile.lock\` loses the sinatra-reloader entry.
- [x] \`bundle exec ruby test/run_all.rb\` — 324 runs / 2600 assertions / 0 failures.
- [x] Local \`bundle exec puma -C conf/puma.rb -e development\` boots, 404 on unmapped route.
- [x] \`docker build .\` produces an image where \`/usr/src/ddbj_validator\` contains only:
  - \`.ruby-version\`, \`Gemfile\`, \`Gemfile.lock\`, \`Rakefile\`, \`config.ru\`
  - \`app/\`, \`bin/\` (no \`bin/deploy*\`), \`conf/\` (no \`conf/pub/\`, no \`conf/coll_dump/\`), \`lib/\`, \`public/\`, \`annotated_sequence_validator/\`
  - No \`test/\`, \`data_updater/\`, \`log_analysis/\`, \`.git/\`, \`.github/\`, \`.mise.toml\`, \`.ruby-lsp/\`, \`Procfile.dev\`
- [x] \`bundle list\` inside the built image shows puma/sinatra/etc. but no \`minitest\`/\`webmock\`/\`rake\`/\`sinatra-reloader\`.
- [x] Container boots Puma end-to-end (4 workers × 1 thread, 404 on unmapped route).
- [ ] Staging deploy via \`bin/deploy staging\` — confirm rolling update succeeds and \`/api/monitoring\` stays healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)