### PR TITLE
Run the app in production mode, not development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN bundle config set --local without 'development test' && bundle install
 COPY ./ ./
 
 EXPOSE 3000
-CMD ["bundle", "exec", "puma", "-C", "/usr/src/ddbj_validator/conf/puma.rb", "-e", "development"]
+CMD ["bundle", "exec", "puma", "-C", "/usr/src/ddbj_validator/conf/puma.rb", "-e", "production"]


### PR DESCRIPTION
## Summary
Flip the Puma CMD from \`-e development\` to \`-e production\`. The validator has been running in Sinatra \`:development\` in staging and production since the Dockerfile was first introduced in 2019-10-25 (commit \`46fba18\`, original CMD \`unicorn … -E development -D\`). The \`-D\` daemonize flag came off 11 days later but \`-E development\` has sat there ever since.

## Why nobody noticed for six years

1. \`app/application.rb\` did \`require 'sinatra/reloader'\` but never \`register Sinatra::Reloader\`, so the most visible dev-mode behavior — auto-reload on file change — simply never fired. PR #151 removed the dead require.
2. The one deliberate dev-gated config, \`set :show_exceptions, development?\` (application.rb:24), only matters on 500s, which the happy path never produces.
3. PR #148's investigation of \`/api/monitoring\` returning \`{status:\"NG\", message:\"...unexpected token at '<!DOCTYPE html>...\"}\` was the first time the ShowExceptions HTML page actually reached a caller. That is exactly the leak we're closing here.

## Security impact
\`show_exceptions: true\` (the dev default) makes Sinatra's ShowExceptions middleware render HTTP 500 responses as an HTML page that includes the **stack trace, env vars, and source snippets** from the failing code path. In production that is an information disclosure waiting to happen. Flipping to \`-e production\` sets \`show_exceptions: false\`, so 500s fall through to Sinatra's default handler (plain text / JSON, no leaked internals).

## Changes
- \`Dockerfile\`: \`-e development\` → \`-e production\`.
- No config or code changes needed — \`set :show_exceptions, development?\` does the right thing under either environment.

## Test plan
- [x] \`docker build .\` clean.
- [x] Inside the running container:
  \`\`\`
  environment     = production
  show_exceptions = false
  raise_errors    = false
  dump_errors     = true
  \`\`\`
- [x] Hitting \`/api/monitoring\` with no Virtuoso reachable now returns HTTP 503 with a plain JSON body instead of the \`<!DOCTYPE html>\` ShowExceptions page.
- [ ] Staging deploy via \`bin/deploy staging\` — confirm the rolling update stays clean and \`/api/monitoring\` still reports 200 when the pipeline is healthy (or 503 when it isn't, not an HTML leak).
- [ ] Promote to production once staging looks good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)