### PR TITLE
Drop haml gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem "csv"
 gem "dotenv"
-gem "haml"
 gem "json-schema"
 gem "mail"
 gem "net-ftp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,6 @@ GEM
     date (3.5.1)
     dotenv (3.1.8)
     drb (2.2.3)
-    haml (6.3.0)
-      temple (>= 0.8.2)
-      thor
-      tilt
     hashdiff (1.2.1)
     json-schema (6.2.0)
       addressable (~> 2.8)
@@ -93,8 +89,6 @@ GEM
       rack-protection (= 4.2.1)
       sinatra (= 4.2.1)
       tilt (~> 2.0)
-    temple (0.10.3)
-    thor (1.3.2)
     tilt (2.7.0)
     time (0.4.1)
       date
@@ -111,7 +105,6 @@ PLATFORMS
 DEPENDENCIES
   csv
   dotenv
-  haml
   json-schema
   mail
   minitest


### PR DESCRIPTION
## Summary
Gemfile declared \`haml\` but:

- no \`.haml\` template lives under \`app/views\` or \`public/\`
- no Ruby file \`require\`s \`haml\` or references \`Haml::\`

The only Sinatra template path in the app is \`erb :index\` from \`/api/client/index\`, which renders \`app/views/index.erb\` — straight ERB, no haml involvement.

## Changes
- \`Gemfile\` / \`Gemfile.lock\`: drop \`haml\`. Transitive \`temple\` drops with it. Dep counts under Ruby 3.4.9 go from 21 → 20 declared, 49 → 45 installed.

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` — 324 runs / 2600 assertions / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)