### PR TITLE
Clean up ValidatorBase#read_common_config

### DIFF
--- a/lib/validator/base.rb
+++ b/lib/validator/base.rb
@@ -22,11 +22,6 @@ class ValidatorBase
     begin
       setting = YAML.load(ERB.new(File.read(config_file_dir + "/validator.yml")).result)
       config[:sparql_config] = setting["sparql_endpoint"]
-      @pg_host = config["pg_host"]
-      @pg_port = config["pg_port"]
-      @pg_user = config["pg_user"]
-      @pg_pass = config["pg_pass"]
-      @pg_timeout = config["pg_timeout"]
       if setting["ddbj_rdb"].nil? \
         || setting["ddbj_rdb"]["pg_host"].nil? || setting["ddbj_rdb"]["pg_host"] == "" \
         || setting["ddbj_rdb"]["pg_port"].nil? || setting["ddbj_rdb"]["pg_port"] == "" \
@@ -46,9 +41,6 @@ class ValidatorBase
       config[:biosample] = setting["biosample"]
       config[:eutils_api_key] = setting["eutils_api_key"]
       config[:log_dir] = setting["api_log"]["path"]
-      config[:log_file] = setting["api_log"]["path"] + "/validator.log"
-      version = YAML.load(ERB.new(File.read(config_file_dir + "/version.yml")).result)
-      config[:version] = version["version"]
       config
     rescue => ex
       message = "Failed to parse the setting file. Please check the config file below.\n"


### PR DESCRIPTION
## Summary
Three dead code blocks in a row in \`lib/validator/base.rb#read_common_config\`:

1. \`@pg_host\` / \`@pg_port\` / \`@pg_user\` / \`@pg_pass\` / \`@pg_timeout\` were assigned from \`config[\"pg_host\"]\` etc. — but \`config\` at that point has no such keys (pg\_\* lives nested under \`config[:ddbj_db_config]\`), so the five instance vars were unconditionally set to \`nil\`. The real pg connections in \`submitter/base.rb\` and \`common/ddbj_db_validator.rb\` build their own config hash with the right nested lookup, so \`ValidatorBase\`'s \`@pg_*\` were never read by anything.
2. \`config[:log_file]\` was assembled but \`@conf[:log_file]\` has no readers. The actual log path used by \`Validator.new\` / \`Submitter.new\` is computed on the fly as \`config[:log_dir] + \"/validator.log\"\`.
3. \`config[:version]\` loaded \`conf/version.yml\` but \`@conf[:version]\` is not read anywhere. \`version.yml\` is opened separately by \`lib/validator/validator.rb\` and \`lib/submitter/submitter.rb\`.

## Changes
- \`lib/validator/base.rb\`: remove the five \`@pg_*\` assignments, the \`config[:log_file]\` entry, and the version.yml load + \`config[:version]\` entry. 8 lines deleted, no other adjustments needed.

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` — 324 runs / 2600 assertions / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)