### PR TITLE
Procfile.dev: unicorn → puma

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bundle exec unicorn -c conf/unicorn.rb
+web: bundle exec puma -C conf/puma.rb
 virtuoso: docker run --volume ./shared/data/virtuoso:/database --publish 8890:8890 openlink/virtuoso-opensource-7:7.2.6-r1-g0a3336c


### PR DESCRIPTION
## Summary
PR #149 migrated the production/staging CMD to Puma but missed \`Procfile.dev\`, so \`overmind start -f Procfile.dev\` (or foreman) still tries \`bundle exec unicorn -c conf/unicorn.rb\` — a config file that no longer exists and a server that is no longer in the Gemfile.

Swap the \`web:\` line to the Puma equivalent. \`virtuoso:\` line untouched.

## Test plan
- [x] \`cat Procfile.dev\` matches the Puma invocation used by Dockerfile (\`bundle exec puma -C conf/puma.rb\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)