### PR TITLE
Phase 1 simplification: .size comparisons + boolean idioms

### DIFF
--- a/app/application.rb
+++ b/app/application.rb
@@ -161,7 +161,7 @@ module DDBJValidator
           file = file_list.select{|file| file.end_with?(".json")} #変換できなかった場合はこのファイルは無い
           type = "application/json"
         end
-        if file.size == 0
+        if file.empty?
           status 400
           message = "Invalid uuid or filetype"
           { status: "error", "message": message}.to_json
@@ -554,7 +554,7 @@ module DDBJValidator
       # Acceptヘッダーをリストで返す
       def get_accept_header(request)
         accept = request.env.select { |k, v| k.start_with?('HTTP_ACCEPT') }
-        if accept.size == 0
+        if accept.empty?
           []
         else
           accept

--- a/lib/package/package.rb
+++ b/lib/package/package.rb
@@ -33,12 +33,12 @@ class Package < SPARQLBase
       params = {version: version}
       sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/package_list.rq", params)
       ret = query(sparql_query)
-      if ret.size > 0
+      if ret.any?
         {status: "success", data: ret}
       else  # 結果が空の場合に存在するversionかチェック
         sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/is_exist_package_version.rq", params)
         ret_package_data = query(sparql_query)
-        if ret_package_data.size == 0
+        if ret_package_data.empty?
           {status: "fail", message: "Wrong parameter: invalid package version"}
         else
           {status: "error", message: "Processing finished with error. Please check the validation service."}
@@ -78,7 +78,7 @@ class Package < SPARQLBase
 
       # mergeして階層型に整形
       package_list.concat(package_group_list)
-      if package_list.size > 0
+      if package_list.any?
         package_tree = []
         package_list.each_with_index do |package_info, idx|
           package_tree = add_package_tree(package_info, package_list, package_tree)
@@ -87,7 +87,7 @@ class Package < SPARQLBase
       else # 結果が空の場合に存在するversionかチェック
         sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/is_exist_package_version.rq", params)
         ret_package_data = query(sparql_query)
-        if ret_package_data.size == 0
+        if ret_package_data.empty?
           {status: "fail", message: "Wrong parameter: invalid package version."}
         else
           {status: "error", message: "Processing finished with error. Please check the validation service."}
@@ -146,7 +146,7 @@ class Package < SPARQLBase
       params = {version: version, package_id: package_id}
       sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/attribute_list.rq", params)
       attr_list = query(sparql_query)
-      if attr_list.size > 0
+      if attr_list.any?
         sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/attribute_group_list.rq", params)
         group_list = query(sparql_query)
         attr_list.each do |row|
@@ -162,7 +162,7 @@ class Package < SPARQLBase
       else # 結果が空の場合に存在するversionかチェック
         sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/is_exist_package_version.rq", params)
         ret_package_data = query(sparql_query)
-        if ret_package_data.size == 0
+        if ret_package_data.empty?
           {status: "fail", message: "Wrong parameter: invalid package version."}
         else
           {status: "fail", message: "Wrong parameter: invalid package version or package id."}
@@ -218,12 +218,12 @@ class Package < SPARQLBase
       params = {version: version, package_id: package_id}
       sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/package_info.rq", params)
       ret = query(sparql_query)
-      if ret.size > 0
+      if ret.any?
         {status: "success", data: ret.first}
       else  # 結果が空の場合に存在するversionかチェック
         sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/is_exist_package_version.rq", params)
         ret_package_data = query(sparql_query)
-        if ret_package_data.size == 0
+        if ret_package_data.empty?
           {status: "fail", message: "Wrong parameter: invalid package version."}
         else
           {status: "fail", message: "Wrong parameter: invalid package version or package id."}

--- a/lib/validator/auto_annotator/auto_annotator_json.rb
+++ b/lib/validator/auto_annotator/auto_annotator_json.rb
@@ -28,7 +28,7 @@ class AutoAnnotatorJson < AutoAnnotatorBase
 
     #auto-annotation出来るエラーのみを抽出
     annotation_list = get_annotated_list(validate_result_file, filetype)
-    if annotation_list.size > 0
+    if annotation_list.any?
       begin
         json_data = JSON.parse(File.read(original_file))
       rescue => ex
@@ -108,7 +108,7 @@ class AutoAnnotatorJson < AutoAnnotatorBase
     add_header_list = add_annotation_list.map {|annotation| annotation["location"]["header"]}.uniq # 列名が異なるがindexが分かれていたり、同じ列名が別indexであるという不整合はないものとする
     add_header_list.each do |add_header| # 追加する項目ごとに処理。全行走査して、補足値を挿入するか空値で挿入するか、
       original_data.each_with_index do |row, row_idx|
-        if row.select{|cell| cell["key"] == add_header["name"]}.size == 0 # 行に追加列名が存在しない
+        if row.none?{|cell| cell["key"] == add_header["name"]} # 行に追加列名が存在しない
           insert_value = nil
           insert_annotation = add_annotation_list.find{|annotation| annotation["location"]["header"]["name"] == add_header["name"] && annotation["location"]["row_idx"] == row_idx}
           unless insert_annotation.nil?

--- a/lib/validator/auto_annotator/auto_annotator_tsv.rb
+++ b/lib/validator/auto_annotator/auto_annotator_tsv.rb
@@ -29,7 +29,7 @@ class AutoAnnotatorTsv < AutoAnnotatorBase
     #auto-annotation出来るエラーのみを抽出
     annotation_list = get_annotated_list(validate_result_file, filetype)
     original_tsv_data = nil
-    if annotation_list.size > 0
+    if annotation_list.any?
       begin
         tsv_data = FileParser.new().parse_csv(original_file, "\t")
         original_tsv_data = tsv_data[:data]

--- a/lib/validator/auto_annotator/auto_annotator_xml.rb
+++ b/lib/validator/auto_annotator/auto_annotator_xml.rb
@@ -30,7 +30,7 @@ class AutoAnnotatorXml < AutoAnnotatorBase
 
     #auto-annotation出来るエラーのみを抽出
     annotation_list = get_annotated_list(validate_result_file, filetype)
-    if annotation_list.size > 0
+    if annotation_list.any?
       begin
         doc = Nokogiri::XML(File.read(original_file))
       rescue => ex # 元ファイルのXMLがParseできない場合はエラー
@@ -39,7 +39,7 @@ class AutoAnnotatorXml < AutoAnnotatorBase
 
       annotation_list.each do |annotation|
         annotation["location"].each do |location| #XPathを取得
-          if doc.xpath(location).size == 0 #XPathで要素/属性がヒットしないなら作成する
+          if doc.xpath(location).empty? #XPathで要素/属性がヒットしないなら作成する
             create_node_from_xapth(doc, location)
           end
           doc.xpath(location).each do |node|
@@ -85,7 +85,7 @@ class AutoAnnotatorXml < AutoAnnotatorBase
     parent_location = ""
     (1..location.split("/").size).each do |pos|
       parent_location = location.split("/")[0..-pos].join("/")
-      if doc.xpath(parent_location).size > 0
+      if doc.xpath(parent_location).any?
         break
       end
     end

--- a/lib/validator/base.rb
+++ b/lib/validator/base.rb
@@ -108,7 +108,7 @@ class ValidatorBase
     schema = Nokogiri::XML::Schema.from_document(xsddoc)
     document = Nokogiri::XML(File.read(xml_file))
     validatan_ret = schema.validate(document)
-    if validatan_ret.size <= 0
+    if validatan_ret.empty?
       result
     else
       schema.validate(document).each do |error|
@@ -193,7 +193,7 @@ class ValidatorBase
     result = true
     begin
       invalid_list = JSON::Validator.fully_validate(schema_json_data, json_data)
-      if invalid_list.size > 0
+      if invalid_list.any?
         result = false
         invalid_list.each do |invalid|
           annotation = [

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -480,7 +480,7 @@ class BioProjectTsvValidator < ValidatorBase
     end
 
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid_field|
           annotation = [
@@ -519,7 +519,7 @@ class BioProjectTsvValidator < ValidatorBase
     end
 
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid|
           annotation = [
@@ -555,7 +555,7 @@ class BioProjectTsvValidator < ValidatorBase
       invalid_list = @tsv_validator.multiple_values(data, allow_multiple_values_conf)
     end
 
-    unless invalid_list.size == 0
+    unless invalid_list.empty?
       result = false
       invalid_list.each do |invalid|
         annotation = [
@@ -592,7 +592,7 @@ class BioProjectTsvValidator < ValidatorBase
     end
 
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid|
           annotation = [
@@ -635,7 +635,7 @@ class BioProjectTsvValidator < ValidatorBase
     end
 
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid|
           annotation = [
@@ -677,7 +677,7 @@ class BioProjectTsvValidator < ValidatorBase
     end
 
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid|
           annotation = [
@@ -720,7 +720,7 @@ class BioProjectTsvValidator < ValidatorBase
       invalid_list["error_internal_ignore"] = @tsv_validator.null_value_is_not_allowed(data, not_allow_null_value_conf["error_internal_ignore"], null_accepted_list, null_not_recommended_list)
     end
     invalid_list.each do |level, list|
-      unless list.size == 0
+      unless list.empty?
         result = false
         list.each do |invalid|
           annotation = [
@@ -752,7 +752,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
     invalid_list = @tsv_validator.invalid_data_format(data)
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: "Field name", value: invalid[:field_name]}]
       if invalid[:value_idx].nil? # field_nameの補正
@@ -783,7 +783,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
     invalid_list = @tsv_validator.non_ascii_characters(data)
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: "Field name", value: invalid[:field_name]}]
       if invalid[:value_idx].nil? # field_nameがNG
@@ -812,7 +812,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
     invalid_list = @tsv_validator.invalid_value_for_null(data, mandatory_field_list, null_accepted_list, null_not_recommended_list)
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]},
@@ -839,7 +839,7 @@ class BioProjectTsvValidator < ValidatorBase
   def missing_field_name(rule_code, data)
     result = true
     invalid_list = @tsv_validator.invalid_value_input(data)
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]},
@@ -871,7 +871,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
     invalid_list = @tsv_validator.null_value_in_optional_field(data, mandatory_field_list, null_accepted_list, null_not_recommended_list)
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]},
@@ -901,7 +901,7 @@ class BioProjectTsvValidator < ValidatorBase
     unless predefined_field_name_conf.nil?
       invalid_list = @tsv_validator.not_predefined_field_name(data, predefined_field_name_conf)
     end
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]}
@@ -925,7 +925,7 @@ class BioProjectTsvValidator < ValidatorBase
   def duplicated_field_name(rule_code, data)
     result = true
     invalid_list = @tsv_validator.duplicated_field_name(data)
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]}
@@ -949,7 +949,7 @@ class BioProjectTsvValidator < ValidatorBase
   def value_in_comment_line(rule_code, data)
     result = true
     invalid_list = @tsv_validator.invalid_value_input(data, "comment_line")
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [
         {key: "Field name", value: invalid[:field_name]},
@@ -983,7 +983,7 @@ class BioProjectTsvValidator < ValidatorBase
       invalid_list = @tsv_validator.missing_mandatory_field_name(data, mandatory_field_names_conf)
     end
 
-    unless invalid_list.size == 0
+    unless invalid_list.empty?
       result = false
       invalid_list.each do |invalid|
         annotation = [

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -213,7 +213,7 @@ class BioProjectValidator < ValidatorBase
 
     duplicated_submission = project_names_list.select{|item| item[:bioproject_title] == title && item[:public_description] == description}
     # submission_idがなければDBから取得したデータではないため、DB内に一つでも同じtitle&descがあるとNG
-    result = false if submission_id.nil? && duplicated_submission.size >= 1
+    result = false if submission_id.nil? && duplicated_submission.any?
     # submission_idがあればDBから取得したデータであり、DB内に同一データが1つある。2つ以上あるとNG
     result = false if !submission_id.nil? && duplicated_submission.size >= 2
 

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -643,7 +643,7 @@ class BioSampleValidator < ValidatorBase
         missing_attr_list.push(attr)
       end
     end
-    if missing_attr_list.size == 0
+    if missing_attr_list.empty?
       true
     else
       missing_attr_list.each do |missing_attr|
@@ -837,7 +837,7 @@ class BioSampleValidator < ValidatorBase
 
     predefined_attr_list = package_attr_list.map {|attr| attr[:attribute_name] } #属性名だけを抽出
     not_predifined_attr_names = sample_attr.keys - predefined_attr_list #属性名の差分をとる
-    if not_predifined_attr_names.size <= 0
+    if not_predifined_attr_names.empty?
       true
     else
       annotation = [
@@ -879,7 +879,7 @@ class BioSampleValidator < ValidatorBase
       end
     end
    
-    if missing_attr_names.size <= 0
+    if missing_attr_names.empty?
       true
     else
       annotation = [
@@ -917,7 +917,7 @@ class BioSampleValidator < ValidatorBase
           end
         end
       end
-      if exist_attr_list.size == 0 #記述属性が一つもない
+      if exist_attr_list.empty? #記述属性が一つもない
         annotation = [
           {key: "Sample name", value: sample_name},
           {key: "Attribute names", value: attr_set.join(", ")}
@@ -950,7 +950,7 @@ class BioSampleValidator < ValidatorBase
       attr[:attribute_name] if attr[:require] == "mandatory"
     }.compact
     missing_attr_names = mandatory_attr_list - sample_attr.keys
-    if missing_attr_names.size <= 0
+    if missing_attr_names.empty?
       true
     else
       annotation = [
@@ -1251,7 +1251,7 @@ class BioSampleValidator < ValidatorBase
     return nil if CommonUtils::null_value?(geo_loc_name) || CommonUtils::null_not_recommended_value?(geo_loc_name)
     country_name = geo_loc_name.split(":").first.strip
     matched_country = country_list.select{|country| country == country_name}
-    if matched_country.size >= 1
+    if matched_country.any?
       true
     else
       annotation = [
@@ -1714,7 +1714,7 @@ class BioSampleValidator < ValidatorBase
       end
     end
 
-    if vouchers_list.size == 0 # 当該属性の記述がない
+    if vouchers_list.empty? # 当該属性の記述がない
       return nil
     elsif vouchers_list.size == 1 # 当該属性の記述が1つだけ
       return true
@@ -1726,7 +1726,7 @@ class BioSampleValidator < ValidatorBase
           multiple_list.concat(inst_list)
         end
       end
-      if multiple_list.size == 0 #同じinstitution_codeが含まれていない
+      if multiple_list.empty? #同じinstitution_codeが含まれていない
         return true
       else
         values = multiple_list.map {|voucher|
@@ -2295,7 +2295,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def identical_attributes (rule_code, biosample_list)
-    return nil if biosample_list.nil? || biosample_list.size == 0
+    return nil if biosample_list.nil? || biosample_list.empty?
 
     result = true
     # 同値比較しない基本属性
@@ -2542,7 +2542,7 @@ class BioSampleValidator < ValidatorBase
 
     # 異なるsubmission_idでlocus_tag_prefixが既にDBに存在していればNG(submission_idの入力がない場合も同様)
     duplicated_list = all_prefix_list.select {|row| row[:locus_tag_prefix] == locus_tag && row[:submission_id] != submission_id}
-    result = false if duplicated_list.size >= 1
+    result = false if duplicated_list.any?
 
     if result == false
       annotation = [
@@ -3264,7 +3264,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def unaligned_sample_attributes(rule_code, biosample_list)
-    return nil if biosample_list.nil? || biosample_list.size == 0
+    return nil if biosample_list.nil? || biosample_list.empty?
     result = true
 
     first_attr_name_list = [] #最初のサンプルの属性名リスト
@@ -3302,7 +3302,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def multiple_packages(rule_code, biosample_list)
-    return nil if biosample_list.nil? || biosample_list.size == 0
+    return nil if biosample_list.nil? || biosample_list.empty?
     result = true
 
     package_list = biosample_list.map {|biosample_data| biosample_data["package"]}
@@ -3337,7 +3337,7 @@ class BioSampleValidator < ValidatorBase
     end
     mandatory_attr_name_list = ["sample_name", "sample_title", "description", "organism", "taxonomy_id", "bioproject_id"]
     missing_attr_list = mandatory_attr_name_list - attr_name_list
-    if missing_attr_list.size > 0
+    if missing_attr_list.any?
       result = false
       annotation = [
         {key: "Sample name", value: sample_name},
@@ -3428,10 +3428,10 @@ class BioSampleValidator < ValidatorBase
       end 
     end
     
-    if submission_id_list.size > 0
+    if submission_id_list.any?
       valid_id_list = @db_validator.get_valid_sample_id_list(submission_id_list, submitter_id)
       invalid_id_list = submission_id_list - valid_id_list # 指定IDから有効なIDを差し引いてinvalidなリストを取得
-      if invalid_id_list.size > 0
+      if invalid_id_list.any?
         annotation = [
           {key: "Sample name", value: sample_name},
           {key: "Attribute", value: "derived_from"},
@@ -3672,7 +3672,7 @@ class BioSampleValidator < ValidatorBase
         end
       end
     end
-    if missing_attr_names.size <= 0
+    if missing_attr_names.empty?
       true
     else
       annotation = [

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -283,10 +283,10 @@ class CombinationValidator < ValidatorBase
     experiment_node = experiment_set.xpath("//EXPERIMENT[@alias]")
     experiment_node.each do |ex_node|
       platform_node = ex_node.xpath("PLATFORM/*[position() = 1]") #PLATFORMの最初の子要素を取得
-      if platform_node.size > 0
+      if platform_node.any?
         platform_name = platform_node[0].name #子要素の要素名を取得し、confから該当するplatformの情報を抽出
         platform_setting = @conf[:platform_filetype].select{|item| item["platform"] == platform_name}
-        if platform_setting.size > 0 #confに記載されたplatform名であれば
+        if platform_setting.any? #confに記載されたplatform名であれば
           accept_filetype_list = platform_setting[0]["filetype"]
           refname = get_node_text(ex_node, "@alias")
           run_set.xpath("//RUN").each_with_index do |run_node, idx|
@@ -299,7 +299,7 @@ class CombinationValidator < ValidatorBase
               end
               # 記載されたfiletypeのリストから許容されたfiletypeを除き、他のfiletypeがあればNG
               unaccept_filetype_list = filetype_list - accept_filetype_list
-              if unaccept_filetype_list.size > 0
+              if unaccept_filetype_list.any?
                 annotation = [
                   {key: "refname", value: refname},
                   {key: "platform", value: platform_name},

--- a/lib/validator/common/common_utils.rb
+++ b/lib/validator/common/common_utils.rb
@@ -204,11 +204,7 @@ class CommonUtils
   # true/false
   #
   def self.blank?(value)
-    if value.nil? || value.to_s.strip.empty?
-      true
-    else
-      false
-    end
+    value.nil? || value.to_s.strip.empty?
   end
 
   #
@@ -223,7 +219,7 @@ class CommonUtils
   def self.null_value?(value)
     if value.nil? || value.to_s.strip.empty?
       true
-    elsif @@null_accepted.select {|refexp| value =~ /^(#{refexp})$/i }.size > 0
+    elsif @@null_accepted.select {|refexp| value =~ /^(#{refexp})$/i }.any?
       true
     else
       false
@@ -242,7 +238,7 @@ class CommonUtils
   def self.null_not_recommended_value?(value)
     ret = false
     if !(value.nil? || value.strip.empty?)
-      if @@null_not_recommended.select {|refexp| value =~ /^(#{refexp})$/i }.size > 0 # null_not_recommendedの正規表現リストにマッチすればNG
+      if @@null_not_recommended.select {|refexp| value =~ /^(#{refexp})$/i }.any? # null_not_recommendedの正規表現リストにマッチすればNG
         ret = true
       end
     end
@@ -268,9 +264,9 @@ class CommonUtils
       else  # reporting termを許容するなら null定義値から削除する
         null_accepted = @@null_accepted.dup.delete_if{|null_value| null_value.start_with?("missing:")}
       end
-      if @@null_not_recommended.select {|refexp| value =~ /^(#{refexp})$/i }.size > 0 # null_not_recommendedの正規表現リストにマッチすればNG
+      if @@null_not_recommended.select {|refexp| value =~ /^(#{refexp})$/i }.any? # null_not_recommendedの正規表現リストにマッチすればNG
         ret = true
-      elsif null_accepted.select {|refexp| value =~ /^(#{refexp})$/i }.size > 0
+      elsif null_accepted.select {|refexp| value =~ /^(#{refexp})$/i }.any?
         ret = true
       else
         # 入力値からnull値を削除する
@@ -490,7 +486,7 @@ class CommonUtils
         begin
           entry_info = JSON.parse(res.body)
           # MedlineCitationSetの中身が空でなければOK
-          if !entry_info["MedlineCitationSet"].nil? && !(entry_info["MedlineCitationSet"].keys.size == 0)
+          if !entry_info["MedlineCitationSet"].nil? && !entry_info["MedlineCitationSet"].keys.empty?
             return true
           else
             return false
@@ -595,7 +591,7 @@ class CommonUtils
         keys.push("culture_collection") if row[1].strip.include?('c')
         keys.push("specimen_voucher") if row[1].strip.include?('s')
         keys.push("bio_material") if row[1].strip.include?('b')
-        next if keys.size == 0
+        next if keys.empty?
         keys.each do |key|
           if row[0].strip.split(":").size == 1 # only institude name
             ret[key.to_sym].push(row[0].strip.split(":").first)

--- a/lib/validator/common/ddbj_db_validator.rb
+++ b/lib/validator/common/ddbj_db_validator.rb
@@ -661,14 +661,14 @@ class DDBJDbValidator
   #  SAMD00000000 はdbから値が取得できないため結果には含まれない
   #
   def get_biosample_metadata(biosample_accession_list)
-    return {} if biosample_accession_list.nil? || biosample_accession_list.size == 0
+    return {} if biosample_accession_list.nil? || biosample_accession_list.empty?
     sample_id_list = []
     biosample_accession_list.each do |accession_id|
       if accession_id =~ /^SAMD\d+/
         sample_id_list.push(accession_id)
       end
     end
-    if sample_id_list.size == 0
+    if sample_id_list.empty?
       return {}
     else
       id_place_holder = (1..sample_id_list.size).map{|idx| "$" + idx.to_s}.join(",")
@@ -725,7 +725,7 @@ class DDBJDbValidator
       end
     end
 
-    if prj_counter_id_list.size > 0
+    if prj_counter_id_list.any?
       begin
         connection = get_connection(BIOPROJCT_DB_NAME)
 
@@ -777,7 +777,7 @@ class DDBJDbValidator
         biosample_id_list.push(biosample_accession)
       end
     end
-    if biosample_id_list.size > 0
+    if biosample_id_list.any?
       begin
         connection = get_connection(BIOSAMPLE_DB_NAME)
         id_place_holder = (1..biosample_id_list.size).map{|idx| "$" + idx.to_s}.join(",")
@@ -827,7 +827,7 @@ class DDBJDbValidator
         run_id_list.push({acc_type: m[:acc_type], acc_no: m[:acc_no].to_i})
       end
     end
-    unless run_id_list.size == 0
+    unless run_id_list.empty?
       # RUN IDのパラメータ分のIN句のquery parameterを組み立てる
       # SQL側 =>  IN ( ($1, $2), ($3, $4) )
       # parameter => ["DRR", 60518, "DRR", 60519]
@@ -892,7 +892,7 @@ class DDBJDbValidator
         biosample_id_list.push(biosample_accession)
       end
     end
-    if biosample_id_list.size > 0
+    if biosample_id_list.any?
       begin
         connection = get_connection(BIOSAMPLE_DB_NAME)
         id_place_holder = (1..biosample_id_list.size).map{|idx| "$" + idx.to_s}.join(",")
@@ -937,7 +937,7 @@ class DDBJDbValidator
     biosample_smp_id_list.each do |smp_id|
       result.push({smp_id: smp_id})
     end
-    if biosample_smp_id_list.size > 0
+    if biosample_smp_id_list.any?
       begin
         connection = get_connection(DRA_DB_NAME)
         id_place_holder = (1..biosample_smp_id_list.size).map{|idx| "$" + idx.to_s}.join(",")
@@ -1003,7 +1003,7 @@ class DDBJDbValidator
     biosample_smp_id_list.each do |smp_id|
       result.push({smp_id: smp_id})
     end
-    if biosample_smp_id_list.size > 0
+    if biosample_smp_id_list.any?
       begin
         connection = get_connection(DRA_DB_NAME)
         id_place_holder = (1..biosample_smp_id_list.size).map{|idx| "$" + idx.to_s}.join(",")
@@ -1071,11 +1071,11 @@ class DDBJDbValidator
     biosample_list_with_smp_id.each do |biosample|
       unless biosample[:smp_id].nil?
         related_project = project_id_list.select{|row| row[:smp_id] == biosample[:smp_id]}
-        if related_project.size > 0 && !related_project[0][:bioproject_accession_id_list].nil?
+        if related_project.any? && !related_project[0][:bioproject_accession_id_list].nil?
           biosample[:bioproject_accession_id_list] = related_project[0][:bioproject_accession_id_list]
         end
         related_run = run_id_list.select{|row| row[:smp_id] == biosample[:smp_id]}
-        if related_run.size > 0 && !related_run[0][:drr_accession_id_list].nil?
+        if related_run.any? && !related_run[0][:drr_accession_id_list].nil?
           biosample[:drr_accession_id_list] = related_run[0][:drr_accession_id_list]
         end
       end
@@ -1108,7 +1108,7 @@ class DDBJDbValidator
         biosample_id_list.push(biosample_accession)
       end
     end
-    if biosample_id_list.size > 0
+    if biosample_id_list.any?
       param_list = [submitter_id].concat(biosample_id_list)
       begin
         connection = get_connection(BIOSAMPLE_DB_NAME)

--- a/lib/validator/common/excel2tsv.rb
+++ b/lib/validator/common/excel2tsv.rb
@@ -122,7 +122,7 @@ class Excel2Tsv
     end
     # 不足シートのリスト
     missing_sheet_list = mandatory_sheet_list - exist_sheet_list
-    if missing_sheet_list.size > 0
+    if missing_sheet_list.any?
       ret = false
       annotation = [
         {key: "Mandatory sheet names", value: mandatory_sheet_list.to_s},

--- a/lib/validator/common/organism_validator.rb
+++ b/lib/validator/common/organism_validator.rb
@@ -57,11 +57,7 @@ class OrganismValidator < SPARQLBase
     params = {organism_name: organism_name, tax_graph_uri: @tax_graph_uri}
     sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/get_taxid_from_name.rq", params)
     result = query(sparql_query)
-    if result.size <= 0
-      false
-    else
-      true
-    end
+    !result.empty?
   end
 
   #
@@ -113,7 +109,7 @@ class OrganismValidator < SPARQLBase
     params = {tax_id: tax_id, tax_graph_uri: @tax_graph_uri}
     sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/get_organism_name.rq", params)
     result = query(sparql_query)
-    if result.size <= 0
+    if result.empty?
       nil
     else
       result.first[:organism_name]
@@ -161,7 +157,7 @@ class OrganismValidator < SPARQLBase
     tax_list = search_tax_from_name_ignore_case(organism_name)
     ret = {}
     #該当するtax_idがない
-    if tax_list.size == 0
+    if tax_list.empty?
       ret[:status] = "no exist"
       ret [:tax_id] = TAX_ROOT
       return ret
@@ -197,7 +193,7 @@ class OrganismValidator < SPARQLBase
     params = {tax_id: tax_id, parent_tax_id: parent_tax_id, tax_graph_uri: @tax_graph_uri}
     sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/has_linage.rq", params)
     result = query(sparql_query)
-    return result.size > 0
+    return result.any?
   end
 
   #
@@ -213,7 +209,7 @@ class OrganismValidator < SPARQLBase
     params = {tax_id: tax_id, tax_graph_uri: @tax_graph_uri}
     sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/has_plastid.rq", params)
     result = query(sparql_query)
-    return result.size > 0
+    return result.any?
   end
 
   #
@@ -233,9 +229,9 @@ class OrganismValidator < SPARQLBase
       params[:rank] = rank
       sparql_query = CommonUtils::binding_template_with_hash("#{@template_dir}/get_parent_rank.rq", params)
       result = query(sparql_query)
-      break if result.size > 0
+      break if result.any?
     end
-    return result.size > 0
+    return result.any?
   end
 
   #

--- a/lib/validator/common/sparql.rb
+++ b/lib/validator/common/sparql.rb
@@ -293,7 +293,7 @@ when "prefix"
   puts serv.prefix
 when "query", "q"
   serv.prefix_default if command == "q"
-  if arguments.size > 0
+  if arguments.any?
     sparql = arguments.shift
     format = arguments.shift
     $stderr.puts "WARNING: invalid format #{format} (use 'xml' or 'json')" if format and not format[/(xml|json)/]
@@ -304,7 +304,7 @@ when "query", "q"
   end
 when "file", "f"
   serv.prefix_default if command == "f"
-  if arguments.size > 0
+  if arguments.any?
     sparql = File.read(arguments.shift)
     format = arguments.shift
     $stderr.puts "WARNING: invalid format #{format} (use 'xml' or 'json')" if format and not format[/(xml|json)/]
@@ -314,7 +314,7 @@ when "file", "f"
     $stderr.puts "> sparql.rb file <filename> [format]"
   end
 when "find"
-  if arguments.size > 0
+  if arguments.any?
     keyword = arguments.shift
     format = arguments.shift
     $stderr.puts "WARNING: invalid format '#{format}' (use 'xml' or 'json')" if format and not format[/(xml|json)/]
@@ -328,7 +328,7 @@ when "head"
     limit, offset, format, = *arguments
   elsif arguments.size > 1
     limit, offset, = *arguments
-  elsif arguments.size > 0
+  elsif arguments.any?
     limit, = *arguments
   end
   opts = {

--- a/lib/validator/common/tsv_column_validator.rb
+++ b/lib/validator/common/tsv_column_validator.rb
@@ -43,7 +43,7 @@ class TsvColumnValidator
 
     header = {}
     tsv_data.each do |row|
-      if header == {} && (row.size == 0 || row[0].nil? || row[0].to_s.chomp.strip.start_with?("#")) #ヘッダー前のコメント行や空白行は無視
+      if header == {} && (row.empty? || row[0].nil? || row[0].to_s.chomp.strip.start_with?("#")) #ヘッダー前のコメント行や空白行は無視
         @row_count_offset += 1  #行数表示用に残しておく
         next
       end

--- a/lib/validator/common/tsv_field_validator.rb
+++ b/lib/validator/common/tsv_field_validator.rb
@@ -28,7 +28,7 @@ class TsvFieldValidator
     end
     tsv_data.each do |row|
       data = {"key" => nil, "values" => []}
-      if row.size == 0 || row[0].nil?
+      if row.empty? || row[0].nil?
         data["key"] = ""
       else
         data["key"] = row[0]
@@ -201,7 +201,7 @@ class TsvFieldValidator
     check_field_list = mandatory_conf
     check_field_list.each do |mandatory_field|
       field_data = data.select{|row| row["key"] == mandatory_field}
-      if field_data.size == 0 # field名がない
+      if field_data.empty? # field名がない
         invalid_list.push(mandatory_field)
       else
         field = field_data.first # 複数fieldを記載していた場合は前方の値を優先
@@ -314,7 +314,7 @@ class TsvFieldValidator
       exist_value = false # group fieldの中で一つでも値があればtrueとする
       group["field_list"].each do |mandatory_field|
         field_data = data.select{|row| row["key"] == mandatory_field}
-        if field_data.size > 0
+        if field_data.any?
           field = field_data.first # 複数fieldを記載していた場合は前方の値を優先
           value_count = 0
           unless field["values"].nil?
@@ -358,9 +358,9 @@ class TsvFieldValidator
             group_field_values[field_name] = field_value(data, field_name, value_idx)
           end
         end
-        if group_field_values.keys.size > 0 # Groupに対する何らかの記載がある
+        if group_field_values.keys.any? # Groupに対する何らかの記載がある
           missing_fields = check_group_conf["mandatory_field"] - group_field_values.keys
-          if missing_fields.size > 0 #mandatory_fieldの記載がない
+          if missing_fields.any? #mandatory_fieldの記載がない
             invalid_list.push({field_group_name: check_group_conf["group_name"], missing_fields: missing_fields, value_idx: value_idx})
           end
         end
@@ -375,7 +375,7 @@ class TsvFieldValidator
     # 同じfieldに値が複数ある場合
     field_name_list = data.map {|row| row["key"]}
     missing_field_name_list = mandatory_field_names_conf - field_name_list
-    if missing_field_name_list.size > 0
+    if missing_field_name_list.any?
       invalid_list.push({field_names: missing_field_name_list.join(", ")})
     end
     invalid_list
@@ -389,7 +389,7 @@ class TsvFieldValidator
   def field_value(data, field_name, value_index=nil)
     value = nil
     field_lines = data.select{|row| row["key"] == field_name}
-    if field_lines.size > 0
+    if field_lines.any?
       # 常に最初に出てきたfield名が優先で、複数ある場合は無視
       row = field_lines.first
       if value_index.nil? # value indexの指定がない場合はvalue_listを返す
@@ -423,7 +423,7 @@ class TsvFieldValidator
         field_lines.push({field_idx: idx}.merge(row))
       end
     }
-    if field_lines.size > 0
+    if field_lines.any?
       # 常に最初に出てきたfield名が優先で、複数ある場合は無視
       row = field_lines.first
       value = {field_idx: row[:field_idx], field_name: row["key"]}

--- a/lib/validator/common/validator_cache.rb
+++ b/lib/validator/common/validator_cache.rb
@@ -30,11 +30,7 @@ class ValidatorCache
   # キャッシュされたキーがあればtrue,なければfalseを返す
   #
   def has_key (cache_name, key)
-    if @cache_data[cache_name].nil? || !@cache_data[cache_name].has_key?(key)
-      false
-    else
-      true
-    end
+    !!@cache_data[cache_name]&.has_key?(key)
   end
 
   #

--- a/lib/validator/jvar_validator.rb
+++ b/lib/validator/jvar_validator.rb
@@ -114,7 +114,7 @@ class JVarValidator < ValidatorBase
         sheet_name = hit[0]
       elsif hit.size > 1
         hit = xlsx.sheets.select {|sheet| sheet.downcase == conf["sheet_name"].downcase } # allow case-insensitive
-        sheet_name = hit[0] if hit.size >= 1
+        sheet_name = hit[0] if hit.any?
       end
       if sheet_name == ""
         #TODO 存在必須シートではエラーを出す。ここか？(OWL定義が来てから)

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -115,7 +115,7 @@ class MetaboBankIdfValidator < ValidatorBase
     invalid_list.concat(invalid_char_on_desc("Study Description", study_desc_value_list))
     invalid_list.concat(invalid_char_on_desc("Protocol Description", protocol_desc_value_list))
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: "Field name", value: invalid[:field_name]}]
       if invalid[:value_idx].nil? # field_nameがNG

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -106,7 +106,7 @@ class MetaboBankSdrfValidator < ValidatorBase
     result = true
     invalid_list = @tsv_validator.non_ascii_characters(data)
 
-    result = false unless invalid_list.size == 0
+    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: "column name", value: invalid[:column_name]}]
       if invalid[:row_idx].nil? # ヘッダーがNG

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -255,7 +255,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_hold_date(rule_code, hold_date_list)
-    return nil if hold_date_list.nil? || hold_date_list.size == 0
+    return nil if hold_date_list.nil? || hold_date_list.empty?
     ret = true
     message = ""
     #if hold_date_list.size != 1
@@ -337,7 +337,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def missing_hold_date(rule_code, hold_date_list)
-    if hold_date_list.nil? || hold_date_list.size == 0
+    if hold_date_list.nil? || hold_date_list.empty?
       range = range_hold_date(Date.today)
       message = "If you like to hold your data until publication, specify 'COMMON/DATE/hold_date' from #{range[:min].strftime("%Y%m%d")} to #{range[:max].strftime("%Y%m%d")}"
       annotation = [
@@ -364,12 +364,12 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def organism_warning(rule_code, organism_data_list, biosample_data_list, organism_info_list=[])
-    return nil if organism_data_list.nil? || organism_data_list.size == 0
+    return nil if organism_data_list.nil? || organism_data_list.empty?
     ret = true
     biosample_data_list = [] if biosample_data_list.nil?
     organism_data_list.each do |line|
       # BioSampleの記載があればスキップする
-      next if biosample_data_list.select{|bs_line| bs_line[:entry] == line[:entry]}.size > 0 || biosample_data_list.select{|bs_line| bs_line[:entry] == "COMMON"}.size > 0
+      next if biosample_data_list.any?{|bs_line| bs_line[:entry] == line[:entry]} || biosample_data_list.any?{|bs_line| bs_line[:entry] == "COMMON"}
 
       valid_flag = true
       organism_name = line[:value]
@@ -453,7 +453,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank(rule_code, organism_info_list)
-    return nil if organism_info_list.nil? || organism_info_list.size == 0
+    return nil if organism_info_list.nil? || organism_info_list.empty?
     ret = true
     organism_info_list.each do |organism|
       valid_flag = true
@@ -499,7 +499,7 @@ class TradValidator < ValidatorBase
     keyword = data_by_feat_qual("KEYWORD", "keyword", anno_by_qual)
     wgs_datatype_list = data_type.select{|line| line[:value].upcase == "WGS" }
     wgs_keyword_list = keyword.select{|line| line[:value].upcase == "WGS" }
-    if wgs_datatype_list.size > 0 || wgs_keyword_list.size > 0
+    if wgs_datatype_list.any? || wgs_keyword_list.any?
       wgs_keyword = true
     end
     # WGSの記載があった場合に complete genome のような内容ではないかチェックする
@@ -510,18 +510,18 @@ class TradValidator < ValidatorBase
         # titleに"complete genome"という文字列が含まれている
         title_lines = data_by_feat_qual("REFERENCE", "title", anno_by_qual)
         title_lines.concat(data_by_feat_qual("source", "ff_definition", anno_by_qual))
-        if title_lines.select{|line| line[:value].downcase.include?("complete genome")}.size > 0
+        if title_lines.any?{|line| line[:value].downcase.include?("complete genome")}
           message = "Found 'complete genome' in REFERENCE/title or source/ff_definition."
           ret = false
         else
           # 複数のエントリがあり、そのうちplasmidが1つ以上含まれている。ただし全てがplasmidではない(chromosomeと推測)
           plasmid_lines = data_by_feat_qual("source", "plasmid", anno_by_qual)
-          if entry_size >= 2 && plasmid_lines.size > 0 && (entry_size - plasmid_lines.size) > 0
+          if entry_size >= 2 && plasmid_lines.any? && (entry_size - plasmid_lines.size) > 0
             message = "Number of entries is a few with including some plasmid entries."
             ret = false
           else
             # COMMONまたはChromosomeの全てのエントリにTOPOLOGY=circularの記載がある
-            if data_by_ent_feat_qual("COMMON", "TOPOLOGY", "circular", anno_by_qual).size > 0
+            if data_by_ent_feat_qual("COMMON", "TOPOLOGY", "circular", anno_by_qual).any?
               message = "Found 'circular' in COMMON/TOPOLOGY/circular"
               ret = false
             else
@@ -532,7 +532,7 @@ class TradValidator < ValidatorBase
               circlar_entry_list = circlar_lines.map{|row| row[:entry]}.uniq
               plasmid_entry_list = plasmid_lines.map{|row| row[:entry]}.uniq #plasmidが含まれていると前の条件ではじくので基本0件
               chromosome_circlar_entry_list = circlar_entry_list - plasmid_entry_list
-              if chromosome_circlar_entry_list.size > 0
+              if chromosome_circlar_entry_list.any?
                 entry_names = chromosome_circlar_entry_list.join(", ")
                 message = "Found 'circular' in TOPOLOGY/circular at entry: #{entry_names}"
                 ret = false
@@ -547,11 +547,11 @@ class TradValidator < ValidatorBase
     if ret == false
       line = []
       key = []
-      if wgs_datatype_list.size > 0
+      if wgs_datatype_list.any?
         key.push("DATATYPE/type")
         line.push(wgs_datatype_list.first[:line_no])
       end
-      if wgs_keyword_list.size > 0
+      if wgs_keyword_list.any?
         key.push("KEYWORD/keyword")
         line.push(wgs_keyword_list.first[:line_no])
       end
@@ -835,11 +835,11 @@ class TradValidator < ValidatorBase
           message_list.compact!
           # 実質的なシステムエラー(Parserが最後まで実行できなかった)が発生した場合は補足する
           fat_list = message_list.select{|row| row[:level] == "FAT"}
-          if fat_list.size > 0 # FATALはユーザエラーとしては扱わない
+          if fat_list.any? # FATALはユーザエラーとしては扱わない
             raise "Parse error: 'ddbj_parser'. Fatal error has occurred. The check by #{parser_name} did not run correctly, so please run it separately.[#{fat_list}]\n"
           end
           sys_list = message_list.select{|row| row[:type] && row[:type] == "SYS"}
-          if sys_list.size > 0 # SystemエラーもユーザエラーでなくFATAL扱い
+          if sys_list.any? # SystemエラーもユーザエラーでなくFATAL扱い
             raise "Parse error: 'ddbj_parser'. System error has occurred. The check by #{parser_name} did not run correctly, so please run it separately.[#{sys_list}]\n"
           end
           if finished_flag == false # finished 行が見当たらず、最後まで実行されたか不明
@@ -920,8 +920,7 @@ class TradValidator < ValidatorBase
     rule_level = (message[:level].start_with?("ER") ||  message[:level].start_with?("FAT")) ? "error" : "warning"
     rule_info["level"] = rule_level
     rule_info["level_orginal"] = message[:level]
-    internal_ignore = message[:level].start_with?("ER1") ? true : false
-    rule_info["internal_ignore"] = internal_ignore
+    rule_info["internal_ignore"] = message[:level].start_with?("ER1")
     rule_info["message"] = message[:message]
     rule_info["reference"] = "https://www.ddbj.nig.ac.jp/ddbj/validator.html#" + message[:code]
     rule_info
@@ -946,7 +945,7 @@ class TradValidator < ValidatorBase
     #COMMON entryにDBLINKがあるか
     common_dblink_exist = false
     common_dblink = dblink_list.select{|row| row[:entry] == "COMMON"}
-    if common_dblink.size > 0
+    if common_dblink.any?
       qual_list = common_dblink.map{|row| row[:qualifier]}
       if qual_list.include?("project") && qual_list.include?("biosample")
         common_dblink_exist = true
@@ -962,7 +961,7 @@ class TradValidator < ValidatorBase
     anno_by_ent.each do |entry_name, data|
       next if entry_name == "COMMON"
       entry_dblink = dblink_list.select{|row| row[:entry] == entry_name}
-      if entry_dblink.size > 0
+      if entry_dblink.any?
         entry_dblink_count += entry_dblink.size
         qual_list = entry_dblink.map{|row| row[:qualifier]}
         unless qual_list.include?("project") && qual_list.include?("biosample")
@@ -982,7 +981,7 @@ class TradValidator < ValidatorBase
     end
 
     if result == false
-      entry_name = missing_dblink_entry_list.size > 0 ? missing_dblink_entry_list.join(", ") : "COMMON"
+      entry_name = missing_dblink_entry_list.any? ? missing_dblink_entry_list.join(", ") : "COMMON"
       annotation = [
         {key: "entry", value: entry_name},
         {key: "File name", value: @anno_file}
@@ -1006,7 +1005,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_accession(rule_code, bioproject_list)
-    return nil if bioproject_list.nil? || bioproject_list.size == 0
+    return nil if bioproject_list.nil? || bioproject_list.empty?
 
     result = true
     invalid_id_list = []
@@ -1053,7 +1052,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_biosample_accession(rule_code, biosample_list)
-    return nil if biosample_list.nil? || biosample_list.size == 0
+    return nil if biosample_list.nil? || biosample_list.empty?
 
     result = true
     invalid_id_list = []
@@ -1100,7 +1099,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_drr_accession(rule_code, drr_list)
-    return nil if drr_list.nil? || drr_list.size == 0
+    return nil if drr_list.nil? || drr_list.empty?
 
     result = true
     invalid_id_list = []
@@ -1178,7 +1177,7 @@ class TradValidator < ValidatorBase
   # SAMD00000000 はdbから値が取得できないため結果には含まれない
   #
   def get_biosample_info(biosample_id_list)
-    return {} if biosample_id_list.nil? || biosample_id_list.size == 0
+    return {} if biosample_id_list.nil? || biosample_id_list.empty?
 
     unless @db_validator.nil?
       ref_biosample_id_list = []
@@ -1194,7 +1193,7 @@ class TradValidator < ValidatorBase
         end
       end
       # noteかderived_fromに記載された
-      if ref_biosample_id_list.size > 0
+      if ref_biosample_id_list.any?
         ref_biosample_info = @db_validator.get_biosample_metadata(ref_biosample_id_list.uniq)
         biosample_info.merge!(ref_biosample_info)
       end
@@ -1234,7 +1233,7 @@ class TradValidator < ValidatorBase
   #    { entry: "Entry1", feature: "source", location: "", qualifier: "isolate", value: "BMS3Abin12", line_no: 24}
   #  ]
   def corresponding_biosample_attr_value(annotation_line_list, biosample_data_list, biosample_info, attribute_name)
-    return [] if annotation_line_list.nil? || annotation_line_list.size == 0
+    return [] if annotation_line_list.nil? || annotation_line_list.empty?
     target_line_list = annotation_line_list.clone
     set_list = []
     target_line_list.each do |target_line|
@@ -1242,10 +1241,10 @@ class TradValidator < ValidatorBase
       entry_name = target_line[:entry]
       # 同じエントリにDBLINK/biosampleの値を検索
       biosample_line = biosample_data_list.select{|bs_line| bs_line[:entry] == entry_name}
-      if biosample_line.size == 0 # なければCOMMON/DBLINK/biosampleの値を検索
+      if biosample_line.empty? # なければCOMMON/DBLINK/biosampleの値を検索
         biosample_line = biosample_data_list.select{|bs_line| bs_line[:entry] == "COMMON"}
       end
-      if biosample_line.size == 0
+      if biosample_line.empty?
         ## TR_R0009:missing_dblink で別途チェックされるのでここでは無視
       else
         biosample_id = biosample_line.first[:value]
@@ -1255,7 +1254,7 @@ class TradValidator < ValidatorBase
         else
           attr_list = biosample_info[biosample_id][:attribute_list]
           target_attribute_list = attr_list.select{|attr| attr[:attribute_name] == attribute_name}
-          if target_attribute_list.size == 0 # BioSample側に当該属性の値がない
+          if target_attribute_list.empty? # BioSample側に当該属性の値がない
             target_line[:biosample] = {biosample_id: biosample_id, attr_value: nil}
           else
             # attribute_value
@@ -1350,20 +1349,20 @@ class TradValidator < ValidatorBase
         attr_list = biosample_info[biosample_id][:attribute_list]
         target_attribute_list = attr_list.select{|attr| attr[:attribute_name] == attribute_name}
         target_attribute_list.delete_if{|attr|  @conf[:bs_null_accepted].include?(attr[:attribute_value]) } # 属性値がnull相当の場合は入力無し扱いとする
-        if target_attribute_list.size > 0 # Biosampleの属性値はある
+        if target_attribute_list.any? # Biosampleの属性値はある
           flag = true
           qual_line = qual_data_list.select{|qual_line| qual_line[:entry] == entry_name}
-          if qual_line.size == 0 # 同じエントリにqualifierデータがなければCOMMONの値を検索
+          if qual_line.empty? # 同じエントリにqualifierデータがなければCOMMONの値を検索
             qual_line = qual_data_list.select{|qual_line| qual_line[:entry] == "COMMON"}
           end
           missing_qual_entry_list = []
-          if qual_line.size == 0 # COMMONのqualifierにも記載がない場合には個別Entryの記載をチェック
+          if qual_line.empty? # COMMONのqualifierにも記載がない場合には個別Entryの記載をチェック
             if entry_name == "COMMON" #BioSampleIDがCOMMONに、qualifierがCOMMON以外に記載されているケースをカバー
               #COMMON以外の全エントリに値があればOK
               exist_entry_name_list = qual_data_list.map{|row| row[:entry]}
               missing_qual_entry_list = all_entry_name_list - exist_entry_name_list - ["COMMON"]
               # 一つでも値がないエントリがあればNG。どのエントリに値がないかを確認
-              if missing_qual_entry_list.size > 0
+              if missing_qual_entry_list.any?
                 flag = false
               end
             else
@@ -1403,7 +1402,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_combination_of_accessions(rule_code, dblink_list, biosample_info)
-    return nil if dblink_list.nil? || dblink_list.size == 0
+    return nil if dblink_list.nil? || dblink_list.empty?
     return nil if biosample_info.nil? || biosample_info == {}
     return nil if @db_validator.nil?
     ret = true
@@ -1425,11 +1424,11 @@ class TradValidator < ValidatorBase
       biosample_line_list.each do |biosample_line|
         biosample_line_with_id = biosample_line.dup
         bioproject_line_list = dblink_list.select{|row| row[:qualifier] == "project" && row[:entry] == entry}
-        if bioproject_line_list.size == 0
+        if bioproject_line_list.empty?
           bioproject_line_list = dblink_list.select{|row| row[:qualifier] == "project" && row[:entry] == "COMMON"}
         end
         run_line_list = dblink_list.select{|row| row[:qualifier] == "sequence read archive" && row[:entry] == entry}
-        if run_line_list.size == 0
+        if run_line_list.empty?
           run_line_list = dblink_list.select{|row| row[:qualifier] == "sequence read archive" && row[:entry] == "COMMON"}
         end
         biosample_line_with_id[:bioproject_id_list] = bioproject_line_list.map{|row| row[:value]}
@@ -1471,9 +1470,9 @@ class TradValidator < ValidatorBase
       end
 
       # Annotationファイルに記述されているBioProjectIDからDRA経由で紐づくIDを引いて、余分なIDがあるかチェックする
-      if linked_bioproject_id_list.size > 0 # BioProjectIDはDRA経由で紐づかないケースもある為、その場合はチェックしない
+      if linked_bioproject_id_list.any? # BioProjectIDはDRA経由で紐づかないケースもある為、その場合はチェックしない
         extra_bioproject_id = biosample_line[:bioproject_id_list] - linked_bioproject_id_list
-        if extra_bioproject_id.size > 0
+        if extra_bioproject_id.any?
           ret = false
           annotation = [
             {key: "DBLINK/biosample", value: biosample_id},
@@ -1488,7 +1487,7 @@ class TradValidator < ValidatorBase
 
       # Annotationファイルに記述されているDRRIDからDBAで経由で紐づくIDを引いて、余分なIDがあるかチェックする
       extra_run_id = biosample_line[:run_id_list] - linked_run_id_list
-      if extra_run_id.size > 0
+      if extra_run_id.any?
         ret = false
         annotation = [
           {key: "DBLINK/biosample", value: biosample_id},
@@ -1517,7 +1516,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def inconsistent_submitter(rule_code, dblink_list, submitter_id)
-    return nil if dblink_list.nil? || dblink_list.size == 0
+    return nil if dblink_list.nil? || dblink_list.empty?
     return nil if submitter_id.nil? || submitter_id == ""
     return nil if @db_validator.nil?
     ret = true
@@ -1545,7 +1544,7 @@ class TradValidator < ValidatorBase
         unmatch_submitter_accession_list.concat(unmatch_submitter_id(link_type, lines, with_submitter_list, submitter_id))
       end
     end
-    if unmatch_submitter_accession_list.size > 0
+    if unmatch_submitter_accession_list.any?
       ret = false
       unmatch_submitter_accession_list.each do |error_line|
         annotation = [
@@ -1588,7 +1587,7 @@ class TradValidator < ValidatorBase
     unmatch_list = []
     dblink_list.each do |dblink|
       hit_list = with_submitter_id_list.select{|row| row[key.to_sym] == dblink[:value] }
-      if hit_list.size == 0
+      if hit_list.empty?
       else
         hit_list.each do |hit|
           if hit[:submitter_id].nil?
@@ -1619,7 +1618,7 @@ class TradValidator < ValidatorBase
   #
   def inconsistent_organism_with_biosample(rule_code, orgnism_data_list, strain_data_list, biosample_data_list, biosample_info)
     # annotationの/organismは必須項目であり、記述がなければjParserでエラーになるため、BioSampleにしか記載がないというチェックは行わない。
-    return nil if orgnism_data_list.nil? || orgnism_data_list.size == 0
+    return nil if orgnism_data_list.nil? || orgnism_data_list.empty?
 
     ret = true
     # 対応するBioSampleとそのorganismとstrain属性値を取得
@@ -1635,7 +1634,7 @@ class TradValidator < ValidatorBase
         trad_strain_value = ""
         # /organismと同じfeatureに/strainの記述があれば対応するBioSampleのstrain属性を取得する
         strain_lines = strain_data_list_with_bs_value.select{|strain_line| strain_line[:feature_no] == organism_line[:feature_no]}
-        if strain_lines.size > 0
+        if strain_lines.any?
           trad_strain_value = strain_lines.first[:value]
           unless strain_lines.first[:biosample][:attr_value_list].nil?
             biosample_strain_attr_values = strain_lines.first[:biosample][:attr_value_list].join(", ")
@@ -1651,7 +1650,7 @@ class TradValidator < ValidatorBase
             message = "Value of organism qualifier is not matched with BioSample attribute."
           else #organismの値が一致する場合はstrainのチェックを行う
             biosample_organism_attr_values = organism_line[:biosample][:attr_value_list].join(", ")
-            if strain_lines.size > 0 #annotation側に/strainの記述がある
+            if strain_lines.any? #annotation側に/strainの記述がある
               if strain_lines.first[:biosample][:attr_value_list].nil? #strain属性がない
                 check = false
                 message = "The strain attribute is not used in BioSample."
@@ -1668,7 +1667,7 @@ class TradValidator < ValidatorBase
               bs_info = biosample_info[organism_line[:biosample][:biosample_id]]
               strain_attr_values = bs_info[:attribute_list].select{|attr| attr[:attribute_name] == 'strain'}
               # TODO ここでmissing等の値を除外するか
-              if strain_attr_values.size > 0 # BioSample側にはstrainの記述がある
+              if strain_attr_values.any? # BioSample側にはstrainの記述がある
                 check = false
                 biosample_strain_attr_values = strain_attr_values.map{|attr| attr[:attribute_value]}.join(", ")
                 message = "The strain qualifier is not found, though the strain attribute is used in BioSample."
@@ -1815,7 +1814,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def inconsistent_locus_tag_with_biosample(rule_code, locus_tag_data_list, biosample_data_list, biosample_info)
-    return nil if locus_tag_data_list.nil? || locus_tag_data_list.size == 0
+    return nil if locus_tag_data_list.nil? || locus_tag_data_list.empty?
     ret = true
     locus_tag_data_list_with_bs_value = corresponding_biosample_attr_value(locus_tag_data_list, biosample_data_list, biosample_info, "locus_tag_prefix")
     faild_list = []
@@ -1841,7 +1840,7 @@ class TradValidator < ValidatorBase
     end
 
     # locus_tagは大量に記述されている可能性があるため、locus_tag_prefix単位にまとめてエラーを出力
-    if faild_list.size > 0
+    if faild_list.any?
       ret = false #1行でもエラーがあればfalse
       faild_list.group_by{|row| row[:trad_locus_tag_prefix_value]}.each do |locus_tag_prefix, lines|
         annotation = [
@@ -1878,7 +1877,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def duplicate_locus_tag(rule_code, locus_tag_data_list, annotation_line_list)
-    return nil if locus_tag_data_list.nil? || locus_tag_data_list.size == 0
+    return nil if locus_tag_data_list.nil? || locus_tag_data_list.empty?
     ret = true
     locus_tag_group = locus_tag_data_list.group_by{|row| row[:value]}
     duplicated_locus_tag = {}
@@ -1887,7 +1886,7 @@ class TradValidator < ValidatorBase
         duplicated_locus_tag[locus_tag_value] = lines
       end
     end
-    if duplicated_locus_tag.keys.size > 0 #重複データが一つでもある場合
+    if duplicated_locus_tag.keys.any? #重複データが一つでもある場合
       all_features = annotation_line_list.group_by{|row| row[:feature_no]} #全行を出現feature毎にグルーピング
       duplicated_locus_tag.each do |locus_tag_value, lines|
         duplicated = false
@@ -1911,11 +1910,11 @@ class TradValidator < ValidatorBase
             message = "Not use the same value for different genes."
           else
             # 特定のfeature種の組合せの場合には許容する
-            if (feature_name_list - ["regulatory", "mRNA", "5’UTR", "3’UTR", "CDS", "exon", "intron", "sig_peptide", "propeptide", "mat_peptide", "transit_peptide"]).size == 0
-            elsif (feature_name_list - ["rRNA", "exon", "intron"]).size == 0
-            elsif (feature_name_list - ["tRNA", "exon", "intron"]).size == 0
-            elsif (feature_name_list - ["nc_RNA", "exon", "intron"]).size == 0
-            elsif (feature_name_list - ["tmRNA", "exon", "intron"]).size == 0
+            if (feature_name_list - ["regulatory", "mRNA", "5’UTR", "3’UTR", "CDS", "exon", "intron", "sig_peptide", "propeptide", "mat_peptide", "transit_peptide"]).empty?
+            elsif (feature_name_list - ["rRNA", "exon", "intron"]).empty?
+            elsif (feature_name_list - ["tRNA", "exon", "intron"]).empty?
+            elsif (feature_name_list - ["nc_RNA", "exon", "intron"]).empty?
+            elsif (feature_name_list - ["tmRNA", "exon", "intron"]).empty?
             else
               duplicated = true
               message = "Not use the same locus_tag for different genes."
@@ -1957,12 +1956,12 @@ class TradValidator < ValidatorBase
         feature_group = lines.group_by{|row| row[:feature_no]} # 個々のfeature毎にgrouping
         feature_group.each do |feature_no, feature_line|
           locus_tag_line = feature_line.select{|row| row[:qualifier] == "locus_tag"}
-          if locus_tag_line.size == 0 # locus_tagの記述が見当たらない
+          if locus_tag_line.empty? # locus_tagの記述が見当たらない
             ret = false
             location_list.push(feature_line.map{|row| row[:line_no]}.min)
           end
         end
-        if location_list.size > 0
+        if location_list.any?
           annotation = [
             {key: "feature", value: feature},
             {key: "File name", value: @anno_file},
@@ -2047,7 +2046,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def other_insdc_partners_accession(rule_code, dblink_list)
-    return nil if dblink_list.nil? || dblink_list.size == 0
+    return nil if dblink_list.nil? || dblink_list.empty?
     ret = true
 
     dblink_list.each{|row|
@@ -2079,7 +2078,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_type(rule_code, bioproject_list)
-    return nil if bioproject_list.nil? || bioproject_list.size == 0
+    return nil if bioproject_list.nil? || bioproject_list.empty?
     return nil if @db_validator.nil?
 
     ret  = true

--- a/lib/validator/validator.rb
+++ b/lib/validator/validator.rb
@@ -81,7 +81,7 @@ class Validator
             end
           end
         end
-        if permission_error_list.size > 0
+        if permission_error_list.any?
           @log.error("File not found or permision denied: #{permission_error_list.join(', ')}")
           ret = {status: "error", format: ARGV[1], message: "permision error: #{permission_error_list.join(', ')}"}
           JSON.generate(ret)
@@ -111,7 +111,7 @@ class Validator
         #error_list.concat(validate("combination", params))
         #TODO dra validator
 
-        if error_list.size == 0
+        if error_list.empty?
           ret = {version: @latest_version, validity: true}
           ret["stats"]  = get_result_stats(error_list)
           ret["messages"] = []
@@ -248,7 +248,7 @@ class Validator
       result["messages"].each do |msg|
         group_key = msg["id"]
         group_data = group_list.select{|group| group["id"] == group_key}
-        if group_data.size == 0
+        if group_data.empty?
           group_list.push({
                             "id" => group_key,
                             "message" => msg["message"],
@@ -338,9 +338,9 @@ class Validator
       @@filetype.each do |filetype|
         autocorrect_item = error_list.select{|item|
           item[:method].casecmp(filetype) == 0 \
-           && item[:annotation].select{|anno| anno[:is_auto_annotation] == true }.size > 0
+           && item[:annotation].any?{|anno| anno[:is_auto_annotation] == true }
         }
-        if autocorrect_item.size > 0
+        if autocorrect_item.any?
           autocorrect[filetype] = true
         else
           autocorrect[filetype] = false


### PR DESCRIPTION
## Summary
Mechanical sweep across \`app/\` and \`lib/\` replacing verbose Ruby idioms with their idiomatic forms. No behaviour change.

| From | To | Notes |
|---|---|---|
| \`.size > 0\` | \`.any?\` | also \`.size >= 1\` |
| \`.size == 0\` / \`<= 0\` / \`< 1\` | \`.empty?\` | |
| \`.select { … }.any?\` | \`.any? { … }\` | one fewer intermediate array |
| \`.select { … }.empty?\` | \`.none? { … }\` | likewise |
| \`if cond; true; else; false; end\` | \`cond\` | only when the body was just \`true\`/\`false\` |
| \`if cond; false; else; true; end\` | \`!(cond)\` | |
| \`unless cond; true; else; false; end\` | \`!(cond)\` | |
| \`cond ? true : false\` | \`cond\` (or \`!!cond\`) | |
| \`cond ? false : true\` | \`!cond\` | |

Two spots needed a hand follow-up after the bulk rewrite:

- \`ValidatorCache#has_key\` was left as \`!(x.nil? || !x.has_key?(key))\` — collapsed to \`!!@cache_data[cache_name]&.has_key?(key)\`.
- \`TradValidator\` rule build had \`internal_ignore = !!message[:level].start_with?(\"ER1\")\`. \`start_with?\` already returns a Boolean, so dropped the \`!!\` and the now-pointless local.

## Stats
23 files touched, +159 / -172 lines. Test suite unchanged: **324 runs / 2600 assertions / 0 failures / 0 errors / 1 pre-existing skip**.

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` — green.
- [x] Spot-check diffs in the 4 hand-edited files (\`common_utils.rb\`, \`organism_validator.rb\`, \`validator_cache.rb\`, \`trad_validator.rb\`).

## Phase 2/3 (separate PRs)
- Introduce an \`add_error\` helper to collapse the 100+ identical \`error_obj\` + \`@error_list.push\` sequences in \`biosample_validator.rb\`.
- Convert the \`result = true; … result = false; … result\` pattern in validator methods to early returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)