### PR TITLE
Phase 2: introduce ValidatorBase#add_error / #add_raw_error

### DIFF
--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -140,8 +140,7 @@ class AnalysisValidator < ValidatorBase
           {key: "center name", value: center_name},
           {key: "Path", value: "//ANALYSIS/@center_name"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -166,8 +165,7 @@ class AnalysisValidator < ValidatorBase
         {key: "Analysis name", value: analysis_label},
         {key: "Path", value: "#{title_path}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -192,8 +190,7 @@ class AnalysisValidator < ValidatorBase
         {key: "DESCRIPTION", value: ""},
         {key: "Path", value: "//ANALYSIS[#{line_num}]/#{desc_path.gsub('//','')}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -221,8 +218,7 @@ class AnalysisValidator < ValidatorBase
             {key: "filename", value: ""},
             {key: "Path", value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result = false
         end
       end
@@ -254,8 +250,7 @@ class AnalysisValidator < ValidatorBase
               {key: "filename", value: filename},
               {key: "Path", value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
             ]
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
             result = false
           end
         end
@@ -288,8 +283,7 @@ class AnalysisValidator < ValidatorBase
               {key: "checksum", value: checksum},
               {key: "Path", value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@checksum"}
             ]
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
             result = false
           end
         end

--- a/lib/validator/base.rb
+++ b/lib/validator/base.rb
@@ -50,6 +50,31 @@ class ValidatorBase
   end
 
   #
+  # rule_code から @validation_config を引いて add_raw_error に渡す薄いラッパ。
+  # 通常の rule check はこちらを使う。
+  #
+  # ==== Args
+  # rule_code: "BS_R0009" 等の rule code (内部で "rule" prefix を付けて @validation_config を引く)
+  # annotation: annotation 配列
+  # auto_annotation: auto-annotation 用メッセージを付け足すかどうか (default: false)
+  # source: error_obj の source フィールド (default: @data_file)
+  #
+  def add_error (rule_code, annotation, auto_annotation: false, source: @data_file)
+    add_raw_error(@validation_config["rule" + rule_code], annotation, auto_annotation: auto_annotation, source: source)
+  end
+
+  #
+  # 既に組み立て済みの rule hash を直接渡す版。trad_validator の ddbj_parser_rule(msg) や
+  # @conf[:validation_parser_config] のように @validation_config 以外から rule を引くケース用。
+  # 戻り値は push したエラー hash (push 後に :external 等を上書きしたい呼び出し元向け)。
+  #
+  def add_raw_error (rule, annotation, auto_annotation: false, source: @data_file)
+    error = CommonUtils.error_obj(rule, source, annotation, auto_annotation)
+    @error_list.push(error)
+    error
+  end
+
+  #
   # Exception発生時のlog出力(backtraceを含む)
   #
   # ==== Args
@@ -87,8 +112,7 @@ class ValidatorBase
         {key: "XML file", value: @data_file},
         {key: "XML error message", value: xml_error_msg}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -116,8 +140,7 @@ class ValidatorBase
           {key: "XML file", value: @data_file},
           {key: "XSD error message", value: error.message}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
       false
     end
@@ -199,8 +222,7 @@ class ValidatorBase
           annotation = [
             {key: "Message", value: invalid}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -225,8 +247,7 @@ class ValidatorBase
       annotation = [
         {key: "Message", value: "Failed to read the file as #{allow_text}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -226,8 +226,7 @@ class BioProjectTsvValidator < ValidatorBase
           {key: "title value", value: title_value},
           {key: "description value", value: description_value}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result
@@ -254,8 +253,7 @@ class BioProjectTsvValidator < ValidatorBase
            {key: "Field name", value: "pubmed_id"},
            {key: "Value", value: pubmed_id}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result = false
         end
       end
@@ -282,8 +280,7 @@ class BioProjectTsvValidator < ValidatorBase
          {key: "Project name", value: "None"},
          {key: "BioProject accession", value: bioproject_accession}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -316,8 +313,7 @@ class BioProjectTsvValidator < ValidatorBase
           {key: "sample_scope", value: sample_scope},
           {key: "Message", value: "When sample_scope is '#{sample_scope}', organism is required."}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       elsif !(CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID)
         result = @org_validator.is_infraspecific_rank(taxonomy_id)
         if result == false
@@ -325,8 +321,7 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "organism", value: organism_name},
             {key: "taxonomy_id", value: taxonomy_id}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -357,8 +352,7 @@ class BioProjectTsvValidator < ValidatorBase
           {key: "organism", value: organism_name},
           {key: "taxonomy_id", value: taxonomy_id}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -398,8 +392,7 @@ class BioProjectTsvValidator < ValidatorBase
       unless scientific_name.nil?
         annotation.push({key: "Message", value: "Organism name of this taxonomy_id: " + scientific_name})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -453,8 +446,7 @@ class BioProjectTsvValidator < ValidatorBase
       msg = "Multiple taxonomies detected with the same organism name. Please provide the taxonomy_id to distinguish the duplicated names."
       annotation.push({key: "Message", value: msg + " taxonomy_id:[#{ret[:tax_id]}]"})
     end #該当するtaxonomy_idが無かった場合は単なるエラー
-    error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation) #このルールではauto-annotation用のメッセージは表示しない
-    @error_list.push(error_hash)
+    add_error(rule_code, annotation) #このルールではauto-annotation用のメッセージは表示しない
     false
   end
 
@@ -486,11 +478,8 @@ class BioProjectTsvValidator < ValidatorBase
           annotation = [
             {key: "Field name", value: invalid_field}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -527,11 +516,8 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "Value", value: invalid[:value]},
             {key: "Position", value: invalid[:field_idx]}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -563,8 +549,7 @@ class BioProjectTsvValidator < ValidatorBase
           {key: "Value", value: invalid[:value]},
           {key: "Position", value: "#{invalid[:field_idx]}"} # TSVだと++1?
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result
@@ -600,11 +585,8 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "Value", value: invalid[:value]},
             {key: "format_type", value: invalid[:format_type]}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -643,11 +625,8 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "Filed names", value: invalid[:field_list].to_s},
             {key: "Meesage", value: "At least one of #{invalid[:field_list].to_s} is required for the '#{invalid[:field_group_name]}' field group."}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -686,11 +665,8 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "Position(value)", value: invalid[:value_idx]},
             {key: "Meesage", value: "#{invalid[:missing_fields].to_s} is required for the '#{invalid[:field_group_name]}' field group."}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -727,11 +703,8 @@ class BioProjectTsvValidator < ValidatorBase
             {key: "Field name", value: invalid[:field_name]},
             {key: "Value", value: invalid[:value]}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          if level == "error_internal_ignore"
-            error_hash[:external] = true
-          end
-          @error_list.push(error_hash)
+          error = add_error(rule_code, annotation)
+          error[:external] = true if level == "error_internal_ignore"
         end
       end
     end
@@ -763,8 +736,7 @@ class BioProjectTsvValidator < ValidatorBase
         location = @tsv_validator.auto_annotation_location(@data_format, invalid[:field_idx], invalid[:value_idx])
         annotation.push(CommonUtils::create_suggested_annotation([invalid[:replace_value]], "Value", location, true))
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -791,8 +763,7 @@ class BioProjectTsvValidator < ValidatorBase
         annotation.push({key: "Value", value: invalid[:value]})
       end
       annotation.push({key: "Invalid Position", value: invalid[:disp_txt]})
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -820,8 +791,7 @@ class BioProjectTsvValidator < ValidatorBase
       ]
       location = @tsv_validator.auto_annotation_location(@data_format, invalid[:field_idx], invalid[:value_idx])
       annotation.push(CommonUtils::create_suggested_annotation([invalid[:replace_value]], "Value", location, true))
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -850,8 +820,7 @@ class BioProjectTsvValidator < ValidatorBase
       elsif @file_format == "json"
         annotation.push( {key: "Potision", value: invalid[:field_idx]})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -879,8 +848,7 @@ class BioProjectTsvValidator < ValidatorBase
       ]
       location = @tsv_validator.auto_annotation_location(@data_format, invalid[:field_idx], invalid[:value_idx])
       annotation.push(CommonUtils::create_suggested_annotation([invalid[:replace_value]], "Value", location, true))
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -906,8 +874,7 @@ class BioProjectTsvValidator < ValidatorBase
       annotation = [
         {key: "Field name", value: invalid[:field_name]}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -930,8 +897,7 @@ class BioProjectTsvValidator < ValidatorBase
       annotation = [
         {key: "Field name", value: invalid[:field_name]}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -960,8 +926,7 @@ class BioProjectTsvValidator < ValidatorBase
       elsif @file_format == "json"
         annotation.push( {key: "Position", value: invalid[:field_idx]})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -989,8 +954,7 @@ class BioProjectTsvValidator < ValidatorBase
         annotation = [
           {key: "Missing field names", value: invalid[:field_names]}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -224,8 +224,7 @@ class BioProjectValidator < ValidatorBase
         {key: "Description", value: description},
         {key: "Path", value: [title_path, desc_path]},
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -254,8 +253,7 @@ class BioProjectValidator < ValidatorBase
           {key: "Description", value: description},
           {key: "Path", value: [title_path, desc_path]},
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -298,8 +296,7 @@ class BioProjectValidator < ValidatorBase
             {key: "ID", value: id},
             {key: "Path", value: "#{pub_path}[#{idx + 1}]/@id"} #順番を表示
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result = false
         end
       rescue => ex #NCBI問合せ中のシステムエラーの場合はその旨メッセージを追加
@@ -310,8 +307,7 @@ class BioProjectValidator < ValidatorBase
           {key: "Path", value: "#{pub_path}[#{idx + 1}]/@id"}, #順番を表示
           {key: "Message", value: "Validation processing failed because connection to NCBI service failed." }
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, false)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -343,8 +339,7 @@ class BioProjectValidator < ValidatorBase
              {key: "BioProject accession", value: bioproject_accession},
              {key: "Path", value: "//Link/Hierarchical[#{idx_h + 1}]/#{member_path}[#{idx_m + 1}]"}
             ]
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
             result = false
           end
         end
@@ -381,8 +376,7 @@ class BioProjectValidator < ValidatorBase
           {key: "OrganismName", value: organism_name},
           {key: "taxID", value: taxonomy_id}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result
@@ -414,8 +408,7 @@ class BioProjectValidator < ValidatorBase
           {key: "OrganismName", value: organism_name},
           {key: "taxID", value: taxonomy_id}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -454,8 +447,7 @@ class BioProjectValidator < ValidatorBase
       unless scientific_name.nil?
         annotation.push({key: "Message", value: "Organism name of this taxonomy_id: " + scientific_name})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -499,8 +491,7 @@ class BioProjectValidator < ValidatorBase
       msg = "Multiple taxonomies detected with the same organism name. Please provide the taxonomy_id to distinguish the duplicated names."
       annotation.push({key: "Message", value: msg + " taxonomy_id:[#{ret[:tax_id]}]"})
     end #該当するtaxonomy_idが無かった場合は単なるエラー
-    error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation) #このルールではauto-annotation用のメッセージは表示しない
-    @error_list.push(error_hash)
+    add_error(rule_code, annotation) #このルールではauto-annotation用のメッセージは表示しない
     false
   end
 end

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -620,8 +620,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Attribute names", value: invalid_headers.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result
     end
   end
@@ -652,8 +651,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: missing_attr.keys.first},
           {key: "Attribute value", value: missing_attr[missing_attr.keys.first]}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
       false
     end
@@ -690,8 +688,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: attr_name},
           {key: "Attribute value", value: all_attr_value.join(", ")}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -717,8 +714,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "package", value: ""}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -753,8 +749,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "package", value: package_name}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     else
       true
@@ -785,8 +780,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "sample_title", value: sample_title}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -814,8 +808,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "organism", value: organism}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -844,8 +837,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Attribute names", value: not_predifined_attr_names.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -886,8 +878,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Attribute names", value: missing_attr_names.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -922,8 +913,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Sample name", value: sample_name},
           {key: "Attribute names", value: attr_set.join(", ")}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         ret = false
       end
     end
@@ -957,8 +947,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Attribute names", value: missing_attr_names.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -1011,8 +1000,7 @@ class BioSampleValidator < ValidatorBase
           location = @xml_convertor.xpath_from_attrname(attr_name, line_num)
         end
         annotation.push(CommonUtils::create_suggested_annotation([replace_value], "Attribute value", location, true));
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation , true)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation, auto_annotation: true)
         result = false
       end
     end
@@ -1048,8 +1036,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: attr_name},
         {key: "Attribute value", value: attr_val}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation , false)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -1113,11 +1100,10 @@ class BioSampleValidator < ValidatorBase
               location = @xml_convertor.xpath_from_attrname(attr_name, line_num)
             end
             annotation.push(CommonUtils::create_suggested_annotation([ref], "Attribute value", location, true));
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
+            add_error(rule_code, annotation, auto_annotation: true)
           else #置換候補がないエラー
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, false)
+            add_error(rule_code, annotation)
           end
-          @error_list.push(error_hash)
           result = false
         end
       rescue => ex #NCBI問合せ中のシステムエラーの場合はその旨メッセージを追加
@@ -1127,8 +1113,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute value", value: attr_val},
           {key: "Message", value: "Validation processing failed because connection to NCBI service failed." }
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, false)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -1168,8 +1153,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "bioproject_id"},
           {key: "Attribute value", value: bioproject_accession}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -1227,8 +1211,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname("geo_loc_name", line_num)
       end
       annotation.push(CommonUtils::create_suggested_annotation([annotated_name], "Attribute value", location, true));
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
       result = false
       false
     end
@@ -1259,8 +1242,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "geo_loc_name"},
         {key: "Attribute value", value: geo_loc_name}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -1297,8 +1279,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname("lat_lon", line_num)
       end
       annotation.push(CommonUtils::create_suggested_annotation([insdc_latlon], "Attribute value", location, true));
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation , true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
     end
     result
   end
@@ -1341,8 +1322,7 @@ class BioSampleValidator < ValidatorBase
       {key: "geo_loc_name", value: geo_loc_name},
       {key: "lat_lon",      value: lat_lon}
     ]
-    error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-    @error_list.push(error_hash)
+    add_error(rule_code, annotation)
     false
   end
 
@@ -1373,8 +1353,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "lat_lon"},
         {key: "Attribute value", value: lat_lon}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation , false)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -1466,12 +1445,8 @@ class BioSampleValidator < ValidatorBase
     end
 
     unless ret
-      unless annotation.find{|anno| anno[:is_auto_annotation] == true}.nil? #auto-annotation有
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      else #auto-annotation無
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      end
-      @error_list.push(error_hash)
+      auto = annotation.any? { it[:is_auto_annotation] }
+      add_error(rule_code, annotation, auto_annotation: auto)
     end
     ret
   end
@@ -1535,8 +1510,7 @@ class BioSampleValidator < ValidatorBase
       msg = "Multiple taxonomies detected with the same organism name. Please provide the taxonomy_id to distinguish the duplicated names."
       annotation.push({key: "Message", value: msg + " taxonomy_id:[#{ret[:tax_id]}]"})
     end #該当するtaxonomy_idが無かった場合は単なるエラー
-    error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation) #このルールではauto-annotation用のメッセージは表示しない
-    @error_list.push(error_hash)
+    add_error(rule_code, annotation) #このルールではauto-annotation用のメッセージは表示しない
     false
   end
 
@@ -1577,8 +1551,7 @@ class BioSampleValidator < ValidatorBase
       unless scientific_name.nil? # Scientific nameが取得できるならtaxonomy_idのscientific_nameを提案する(自動補正はしない)
         annotation.push({key: "Message", value: "Organism name of this taxonomy_id: " + scientific_name})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -1619,8 +1592,7 @@ class BioSampleValidator < ValidatorBase
         {key: "package", value: package_name},
         {key: "Message", value: message}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     else
       true
@@ -1682,8 +1654,7 @@ class BioSampleValidator < ValidatorBase
           {key: "sex", value: sex},
           {key: "Message", value: message}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     ret
@@ -1737,8 +1708,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attributes", value: multiple_list.map{|voucher|voucher[:attr_name]}.uniq.join(", ")},
           {key: "Values", value: values},
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         return false
       end
     end
@@ -1810,8 +1780,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "collection_date"},
         {key: "Attribute value", value: collection_date}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -1883,8 +1852,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname_with_index(attr_name, line_num, attr_no)
       end
       annotation.push(CommonUtils::create_suggested_annotation([attr_val_result], "Attribute value", location, true));
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
       result = false
     else
       result = true
@@ -1943,8 +1911,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname(attr_name, line_num)
       end
       annotation.push(CommonUtils::create_suggested_annotation([attr_val], "Attribute value", location, true))
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
       result = false
     end
     result
@@ -1981,8 +1948,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: attr_name},
         {key: "Attribute value", value: attr_val}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -2037,8 +2003,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute name", value: attr_name}
       ]
       annotation.push({key:"Suggestion",value: replaced})
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     elsif target == "attr_value" && replaced != attr_val
       annotation = [
@@ -2047,8 +2012,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute value", value: attr_val}
       ]
       annotation.push({key:"Suggestion",value: replaced})
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -2090,8 +2054,7 @@ class BioSampleValidator < ValidatorBase
         {key: "host", value: host},
         {key: "isolation_source", value: isolation_source}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       return false
     end
   end
@@ -2142,8 +2105,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname_with_index(attr_name, line_num, attr_no)
       end
       annotation.push(CommonUtils::create_suggested_annotation([replaced], "Attribute name", location, true))
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
       result = false
     elsif target == "attr_value" && replaced != attr_val #属性値のAuto-annotationが必要
       annotation = [
@@ -2157,8 +2119,7 @@ class BioSampleValidator < ValidatorBase
         location = @xml_convertor.xpath_from_attrname_with_index(attr_name, line_num, attr_no)
       end
       annotation.push(CommonUtils::create_suggested_annotation([replaced], "Attribute value", location, true))
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, auto_annotation: true)
       result = false
     end
     result
@@ -2196,8 +2157,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute value", value: attr_val},
         {key: "Position", value: disp_attr_val}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -2233,8 +2193,7 @@ class BioSampleValidator < ValidatorBase
             {key: "Sample name", value: sample_data[:sample_name]},
             {key: "Title", value: sample_title}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result= false
         end
       end
@@ -2275,8 +2234,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Submitter ID", value: submitter_id},
         {key: "bioproject_id", value: bioproject_accession}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -2333,8 +2291,7 @@ class BioSampleValidator < ValidatorBase
             {key: "Sample name", value: sample["sample_name"]},
             {key: "Sample group without distinguishing attribute", value: group_idx.to_s}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
         group_idx += 1
         result = false
@@ -2371,8 +2328,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Sample name", value: sample_name},
           {key: "bioproject_id", value: bioproject_accession}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -2407,8 +2363,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: attr_name},
           {key: "Attribute value", value: attr_val}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result
@@ -2445,8 +2400,7 @@ class BioSampleValidator < ValidatorBase
             {key: "Sample name", value: sample_name},
             {key: "Sample title", value: sample_data[:sample_title]} #sample_nameが同一なので、Titleを個々のサンプルの識別しとして表示する
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result= false
         end
       end
@@ -2496,8 +2450,7 @@ class BioSampleValidator < ValidatorBase
             {key: "Sample name", value: biosample_data["attributes"]["sample_name"]},
             {key: "Attribute", value: biosample_data["attributes"]["bioproject_id"]}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     else
@@ -2550,8 +2503,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "locus_tag_prefix"},
           {key: "Attribute value", value: locus_tag}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -2596,8 +2548,7 @@ class BioSampleValidator < ValidatorBase
           location = @xml_convertor.xpath_from_attrname("bioproject_id", line_num)
         end
         annotation.push(CommonUtils::create_suggested_annotation([biosample_accession], "Attribute value", location, true))
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation, auto_annotation: true)
         result = false
       end
     end
@@ -2626,8 +2577,7 @@ class BioSampleValidator < ValidatorBase
           {key: "taxonomy_id", value: taxonomy_id},
           {key: "organism", value: organism}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -2667,8 +2617,7 @@ class BioSampleValidator < ValidatorBase
       result = false
     end
     if result == false
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -2695,8 +2644,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "locus_tag_prefix"},
           {key: "Attribute value", value: locus_tag}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -2741,8 +2689,7 @@ class BioSampleValidator < ValidatorBase
           location = @xml_convertor.xpath_from_attrname(optional_attr, line_num) # TODO attr_no
         end
         annotation.push(CommonUtils::create_suggested_annotation([""], "Attribute value", location, true))
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -2766,8 +2713,7 @@ class BioSampleValidator < ValidatorBase
       annotation = [
         {key: "Sample name", value: sample_name}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -2812,8 +2758,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute name", value: "organism"},
           {key: "Attribute value", value: organism}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
     end
     result
   end
@@ -2865,12 +2810,8 @@ class BioSampleValidator < ValidatorBase
     end
 
     unless ret
-      unless annotation.find{|anno| anno[:is_auto_annotation] == true}.nil? #auto-annotation有
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation, true)
-      else #auto-annotation無
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      end
-      @error_list.push(error_hash)
+      auto = annotation.any? { it[:is_auto_annotation] }
+      add_error(rule_code, annotation, auto_annotation: auto)
     end
     ret
   end
@@ -2933,8 +2874,7 @@ class BioSampleValidator < ValidatorBase
         attr_no = " (Attribute no: #{attr_idx})"
         annotation.push({key: "Suggested value" + attr_no, value: has_linage_metagenome[:annotation_name]})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -2962,8 +2902,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "culture_collection"},
         {key: "Attribute value", value: culture_collection}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3011,8 +2950,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "specimen_voucher"},
         {key: "Attribute value", value: specimen_voucher}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3040,8 +2978,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "specimen_voucher"},
         {key: "Attribute value", value: specimen_voucher}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3089,8 +3026,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute", value: "bio_material"},
         {key: "Attribute value", value: bio_material}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3178,8 +3114,7 @@ class BioSampleValidator < ValidatorBase
         end
         annotation.push(CommonUtils::create_suggested_annotation([replaced_value], "Attribute value", location, true))
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3217,8 +3152,7 @@ class BioSampleValidator < ValidatorBase
       unless message == ""
         annotation.push({key: "Message", value: message})
       end
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3245,8 +3179,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "gisaid_accession"},
           {key: "Attribute value", value: gisaid_accession}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -3283,8 +3216,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Sample name", value: biosample_data["attributes"]["sample_name"]},
           {key: "Message", value: "Difference from the attribute names and order in the first sample."}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     result
@@ -3311,8 +3243,7 @@ class BioSampleValidator < ValidatorBase
       annotation = [
         {key: "Package names", value: package_list.uniq.to_s}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -3343,8 +3274,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Missing attribute names", value: missing_attr_list.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -3391,8 +3321,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Attribute value(locus_tag_prefix)", value: locus_tag_prefix_values.join(", ")},
         {key: "Attribute value(bioproject_id)", value: bioproject_id_values.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -3437,8 +3366,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "derived_from"},
           {key: "Invalid Accession IDs", value: invalid_id_list.join(", ")}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -3536,8 +3464,7 @@ class BioSampleValidator < ValidatorBase
         {key: "package", value: package_name},
         {key: "attibutes", value: mandatory_attr_list_to_message.join("/")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -3595,8 +3522,7 @@ class BioSampleValidator < ValidatorBase
           {key: "strain", value: strain.to_s},
           {key: "isolate", value: isolate.to_s}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
     end
     result
   end
@@ -3637,8 +3563,7 @@ class BioSampleValidator < ValidatorBase
           {key: "Attribute", value: "strain"},
           {key: "Attribute value", value: strain}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -3679,8 +3604,7 @@ class BioSampleValidator < ValidatorBase
         {key: "Sample name", value: sample_name},
         {key: "Attribute names", value: missing_attr_names.join(", ")}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       false
     end
   end
@@ -3690,7 +3614,7 @@ class BioSampleValidator < ValidatorBase
     return true unless organism = data.dig("attributes", "organism")
     return true unless organism.match?(/ sp\.\z/i)
 
-    @error_list.push CommonUtils.error_obj(@validation_config["ruleBS_R0140"], @data_file, [
+    add_error("BS_R0140", [
       {
         key:   "Sample name",
         value: data.dig("attributes", "sample_name")
@@ -3713,7 +3637,7 @@ class BioSampleValidator < ValidatorBase
     return true unless organism = data.dig("attributes", "organism")
     return true unless organism.start_with?(/uncultured /i)
 
-    @error_list.push CommonUtils.error_obj(@validation_config["ruleBS_R0141"], @data_file, [
+    add_error("BS_R0141", [
       {
         key:   "Sample name",
         value: data.dig("attributes", "sample_name")

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -23,7 +23,7 @@ class CombinationValidator < ValidatorBase
 
     @error_list = error_list = []
 
-    @dra_validation_config = @conf[:dra_validation_config] #need?
+    @validation_config = @conf[:validation_config] #need?
     unless @conf[:ddbj_db_config].nil?
       @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
       @use_db = true
@@ -43,7 +43,7 @@ class CombinationValidator < ValidatorBase
   def read_config (config_file_dir)
     config = {}
     begin
-      config[:dra_validation_config] = JSON.parse(File.read(config_file_dir + "/rule_config_dra.json")) #TODO auto update when genereted
+      config[:validation_config] = JSON.parse(File.read(config_file_dir + "/rule_config_dra.json")) #TODO auto update when genereted
       config[:platform_filetype] = JSON.parse(File.read(config_file_dir + "/platform_filetype.json"))
       config
     rescue => ex
@@ -137,8 +137,7 @@ class CombinationValidator < ValidatorBase
         {key: "STUDY_REF", value: ref_project_list.to_s},
         {key: "Path", value: "//EXPERIMENT/STUDY_REF/@accession, //ANALYSIS/STUDY_REF/@accession"}
       ]
-      error_hash = CommonUtils::error_obj(@dra_validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -175,8 +174,7 @@ class CombinationValidator < ValidatorBase
             {key: "refname", value: refname},
             {key: "Path", value: "//RUN[#{idx}]/#{refname_path}"}
           ]
-          error_hash = CommonUtils::error_obj(@dra_validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result = false
         end
       end
@@ -215,8 +213,7 @@ class CombinationValidator < ValidatorBase
                 {key: "refname", value: refname},
                 {key: "Path", value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
               ]
-              error_hash = CommonUtils::error_obj(@dra_validation_config["rule" + rule_code], @data_file, annotation)
-              @error_list.push(error_hash)
+              add_error(rule_code, annotation)
               result = false
             end
           end
@@ -257,8 +254,7 @@ class CombinationValidator < ValidatorBase
                 {key: "refname", value: refname},
                 {key: "Path", value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
               ]
-              error_hash = CommonUtils::error_obj(@dra_validation_config["rule" + rule_code], @data_file, annotation)
-              @error_list.push(error_hash)
+              add_error(rule_code, annotation)
               result = false
             end
           end
@@ -306,8 +302,7 @@ class CombinationValidator < ValidatorBase
                   {key: "filetype", value: unaccept_filetype_list.uniq.to_s},
                   {key: "Path", value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
                 ]
-                error_hash = CommonUtils::error_obj(@dra_validation_config["rule" + rule_code], @data_file, annotation)
-                @error_list.push(error_hash)
+                add_error(rule_code, annotation)
                 result = false
               end
             end

--- a/lib/validator/common/common_utils.rb
+++ b/lib/validator/common/common_utils.rb
@@ -79,28 +79,6 @@ class CommonUtils
   end
 
   #
-  # エラーオブジェクトを組み立てて返す
-  # 但し、ルール定義の設定を引数overrideで変える場合に使用する。例: level(wargnin|eror)を変えたい, objectを変えたい
-  # フォーマット(JSON)は以下を参照
-  # https://github.com/ddbj/ddbj_validator/wiki/Validator-API#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E4%BB%95%E6%A7%98json%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%83%E3%83%88
-  # ==== Args
-  # rule: ルールのオブジェクト
-  # file_path: 検証対象のファイルパス
-  # annotation: annotation list for correcting the value
-  # override: 上書きしたいrule情報
-  # auto_annotation: true/false Auto annotationかどうか
-  # ==== Return
-  # エラーのHashオブジェクト
-  #
-  def self.error_obj_override (rule, file_path, annotation, override, *auto_annotaion)
-    hash = error_obj(rule, file_path, annotation, *auto_annotaion)
-    override.each do |k, v|
-      hash[k] = v
-    end
-    hash
-  end
-
-  #
   # Suggest形式のannotation情報のhashを組み立てて返す.
   # デフォルトのkey名("Suggested value")を使用したくない場合に指定できる(複数のSuggested項目がある場合に識別するケース等)
   # フォーマット(JSON)は以下を参照

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -140,8 +140,7 @@ class ExperimentValidator < ValidatorBase
           {key: "center name", value: center_name},
           {key: "Path", value: "//EXPERIMENT/@center_name"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -166,8 +165,7 @@ class ExperimentValidator < ValidatorBase
         {key: "Experimentt name", value: experiment_label},
         {key: "Path", value: "#{title_path}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -191,8 +189,7 @@ class ExperimentValidator < ValidatorBase
         {key: "Experimentt name", value: experiment_label},
         {key: "Path", value: "#{desc_path}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -216,8 +213,7 @@ class ExperimentValidator < ValidatorBase
         {key: "Experimentt name", value: experiment_label},
         {key: "Path", value: "#{lib_path}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -243,8 +239,7 @@ class ExperimentValidator < ValidatorBase
           {key: "Experimentt name", value: experiment_label},
           {key: "Path", value: "#{length_path}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -273,8 +268,7 @@ class ExperimentValidator < ValidatorBase
           {key: "Nominal length", value: "#{length}"},
           {key: "Path", value: "#{length_path}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end

--- a/lib/validator/jvar_validator.rb
+++ b/lib/validator/jvar_validator.rb
@@ -83,8 +83,7 @@ class JVarValidator < ValidatorBase
         {key: "Excel file", value: @data_file},
         {key: "Error message", value: ex.message}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       message = "Failed to load the Excel file.: Please check the files: '#{data_xlsx}'.\n"
       message += "#{ex.message} (#{ex.class})"
       @log.warn("An Excel(Roo::Excelx) loading error has occurred.")
@@ -147,8 +146,7 @@ class JVarValidator < ValidatorBase
         {key: "Sheet name", value: sheet_name},
         {key: "Error message", value: ex.message}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       message = "Failed to load the Excel file.: Please check the files: '#{@data_file}'.\n"
       message += "#{ex.message} (#{ex.class})"
       @log.warn("An Excel(Roo::Excelx) sheet loading error has occurred.")
@@ -240,8 +238,7 @@ class JVarValidator < ValidatorBase
         {key: "Excel file", value: @data_file},
         {key: "Sheet name", value: sheet_name}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -259,8 +256,7 @@ class JVarValidator < ValidatorBase
         {key: "Sheet name", value: sheet_name},
         {key: "line number", value: row_num}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -278,8 +274,7 @@ class JVarValidator < ValidatorBase
         {key: "Sheet name", value: sheet_name},
         {key: "line number", value: row_num}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end
@@ -300,8 +295,7 @@ class JVarValidator < ValidatorBase
           {key: "Cell", value: cell_pos},
           {key: "Value", value: cell_value(cell)}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     ret
@@ -320,8 +314,7 @@ class JVarValidator < ValidatorBase
         {key: "Sheet name", value: sheet_name},
         {key: "line number", value: row_num}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     ret
   end

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -123,8 +123,7 @@ class MetaboBankIdfValidator < ValidatorBase
         annotation.push({key: "Value", value: invalid[:value]})
       end
       annotation.push({key: "Invalid Position", value: invalid[:disp_txt]})
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -115,8 +115,7 @@ class MetaboBankSdrfValidator < ValidatorBase
         annotation.push({key: "Value", value: invalid[:value]})
       end
       annotation.push({key: "Invalid Position", value: invalid[:disp_txt]})
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -140,8 +140,7 @@ class RunValidator < ValidatorBase
           {key: "center name", value: center_name},
           {key: "Path", value: "//RUN/@center_name"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -166,8 +165,7 @@ class RunValidator < ValidatorBase
         {key: "Run name", value: run_label},
         {key: "Path", value: "#{title_path}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -195,8 +193,7 @@ class RunValidator < ValidatorBase
             {key: "filename", value: ""},
             {key: "Path", value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           result = false
         end
       end
@@ -228,8 +225,7 @@ class RunValidator < ValidatorBase
               {key: "filename", value: filename},
               {key: "Path", value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
             ]
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
             result = false
           end
         end
@@ -262,8 +258,7 @@ class RunValidator < ValidatorBase
               {key: "checksum", value: checksum},
               {key: "Path", value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@checksum"}
             ]
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
             result = false
           end
         end
@@ -296,8 +291,7 @@ class RunValidator < ValidatorBase
         {key: "filetypes", value: filetype_list.to_s},
         {key: "Path", value: "//RUN[#{line_num}]/#{filetype_path.gsub('//', '')}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result
@@ -331,8 +325,7 @@ class RunValidator < ValidatorBase
         {key: "filetypes", value: org_filetype_list.to_s},
         {key: "Path", value: "//RUN[#{line_num}]/#{filetype_path.gsub('//', '')}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
       result = false
     end
     result

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -134,8 +134,7 @@ class SubmissionValidator < ValidatorBase
           {key: "center name", value: center_name},
           {key: "Path", value: "//SUBMISSION/@center_name"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
         result = false
       end
     end
@@ -174,8 +173,7 @@ class SubmissionValidator < ValidatorBase
             {key: "HoldUntilDate", value: date_text},
             {key: "Path", value: "#{data_path}[#{idx + 1}]"} #順番を表示
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -297,8 +297,7 @@ class TradValidator < ValidatorBase
           {key: "Message", value: message},
           {key: "Location", value: "Line: #{hold_date_list.first[:line_no]}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @anno_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation, source: @anno_file)
       end
     end
     ret
@@ -343,8 +342,7 @@ class TradValidator < ValidatorBase
       annotation = [
         {key: "Message", value: message},
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @anno_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, source: @anno_file)
       false
     else
       true
@@ -435,8 +433,7 @@ class TradValidator < ValidatorBase
       end
       if valid_flag == false
         ret = false
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @anno_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation, source: @anno_file)
       end
     end
     ret
@@ -469,8 +466,7 @@ class TradValidator < ValidatorBase
           {key: "Location", value: "Line: #{organism[:line_no]}"},
           {key: "taxonomy_id", value: organism[:tax_id]}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @anno_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation, source: @anno_file)
       end
       if valid_flag == false
         ret = false
@@ -561,8 +557,7 @@ class TradValidator < ValidatorBase
         {key: "Location", value: "Line: #{line.join(", ")}"}
       ]
       annotation.push({key: "Message", value: message}) unless message == ""
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @anno_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, source: @anno_file)
     end
     ret
   end
@@ -598,8 +593,7 @@ class TradValidator < ValidatorBase
         {key: "annotation file", value: @anno_file},
         {key: "fasta file", value: @seq_file}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, source: "#{@anno_file}, #{@seq_file}")
       ret = false
     end
     # 個別のerror/warningからエラーメッセージを追加する
@@ -622,12 +616,8 @@ class TradValidator < ValidatorBase
       annotation.push({key: "Location", value: msg[:location]}) if msg[:location]
       annotation.push({key: "Message", value: msg[:message]})
       parser_rule_code = msg[:code]
-      if @conf[:validation_parser_config]["rule" + parser_rule_code].nil?
-        error_hash = CommonUtils::error_obj(ddbj_parser_rule(msg), "#{@anno_file}, #{@seq_file}", annotation)
-      else
-        error_hash = CommonUtils::error_obj(@conf[:validation_parser_config]["rule" + parser_rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      end
-      @error_list.push(error_hash)
+      rule = @conf[:validation_parser_config]["rule" + parser_rule_code] || ddbj_parser_rule(msg)
+      add_raw_error(rule, annotation, source: "#{@anno_file}, #{@seq_file}")
     end
     ret
   end
@@ -665,8 +655,7 @@ class TradValidator < ValidatorBase
         {key: "annotation file", value: @anno_file},
         {key: "fasta file", value: @seq_file}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, source: "#{@anno_file}, #{@seq_file}")
       ret = false
     end
     # 個別のerror/warningからエラーメッセージを追加する
@@ -679,12 +668,8 @@ class TradValidator < ValidatorBase
         {key: "Message", value: msg[:message]}
       ]
       parser_rule_code = msg[:code]
-      if @conf[:validation_parser_config]["rule" + parser_rule_code].nil?
-        error_hash = CommonUtils::error_obj(ddbj_parser_rule(msg), "#{@anno_file}, #{@seq_file}", annotation)
-      else
-        error_hash = CommonUtils::error_obj(@conf[:validation_parser_config]["rule" + parser_rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      end
-      @error_list.push(error_hash)
+      rule = @conf[:validation_parser_config]["rule" + parser_rule_code] || ddbj_parser_rule(msg)
+      add_raw_error(rule, annotation, source: "#{@anno_file}, #{@seq_file}")
     end
     ret
   end
@@ -722,8 +707,7 @@ class TradValidator < ValidatorBase
         {key: "annotation file", value: @anno_file},
         {key: "fasta file", value: @seq_file}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation, source: "#{@anno_file}, #{@seq_file}")
       ret = false
     end
     # 個別のerror/warningからエラーメッセージを追加する
@@ -736,12 +720,8 @@ class TradValidator < ValidatorBase
       annotation.push({key: "Location", value: msg[:location]}) if msg[:location]
       annotation.push({key: "Message", value: msg[:message]})
       parser_rule_code = msg[:code]
-      if @conf[:validation_parser_config]["rule" + parser_rule_code].nil?
-        error_hash = CommonUtils::error_obj(ddbj_parser_rule(msg), "#{@anno_file}, #{@seq_file}", annotation)
-      else
-        error_hash = CommonUtils::error_obj(@conf[:validation_parser_config]["rule" + parser_rule_code], "#{@anno_file}, #{@seq_file}", annotation)
-      end
-      @error_list.push(error_hash)
+      rule = @conf[:validation_parser_config]["rule" + parser_rule_code] || ddbj_parser_rule(msg)
+      add_raw_error(rule, annotation, source: "#{@anno_file}, #{@seq_file}")
     end
     ret
   end
@@ -987,8 +967,7 @@ class TradValidator < ValidatorBase
         {key: "File name", value: @anno_file}
       ]
       annotation.push({key: "Message", value: message}) unless message == ""
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
 
     result
@@ -1035,8 +1014,7 @@ class TradValidator < ValidatorBase
         {key: "File name", value: @anno_file},
         {key: "Location", value: "Line: #{line_no_list.join(", ")}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -1082,8 +1060,7 @@ class TradValidator < ValidatorBase
         {key: "File name", value: @anno_file},
         {key: "Location", value: "Line: #{line_no_list.join(", ")}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -1125,8 +1102,7 @@ class TradValidator < ValidatorBase
         {key: "File name", value: @anno_file},
         {key: "Location", value: "Line: #{line_no_list.join(", ")}"}
       ]
-      error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-      @error_list.push(error_hash)
+      add_error(rule_code, annotation)
     end
     result
   end
@@ -1318,8 +1294,7 @@ class TradValidator < ValidatorBase
             {key: "Location", value: "Line: #{line[:line_no]}"}
           ]
           annotation.push({key: "Message", value: message}) unless message == ""
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -1382,8 +1357,7 @@ class TradValidator < ValidatorBase
               {key: "Location", value: "Line: #{biosample_line[:line_no]}"}
             ]
             annotation.push({key: "Message", value: "BioSample[#{biosample_id})] has '#{attribute_name}' attribute value, but qualifier '#{qualifier_name}' is not used."})
-            error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-            @error_list.push(error_hash)
+            add_error(rule_code, annotation)
           end
         end
       end
@@ -1480,8 +1454,7 @@ class TradValidator < ValidatorBase
             {key: "File name", value: @anno_file},
             {key: "Location", value: "Line: #{biosample_line[:line_no]}"}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
 
@@ -1495,8 +1468,7 @@ class TradValidator < ValidatorBase
           {key: "File name", value: @anno_file},
           {key: "Location", value: "Line: #{biosample_line[:line_no]}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
 
@@ -1553,8 +1525,7 @@ class TradValidator < ValidatorBase
           {key: "File name", value: @anno_file},
           {key: "Location", value: "Line: #{error_line[:line_no]}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     ret
@@ -1687,8 +1658,7 @@ class TradValidator < ValidatorBase
             {key: "Location", value: "Line: #{organism_line[:line_no]}"}
           ]
           annotation.push({key: "Message", value: message}) unless message == ""
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -1850,8 +1820,7 @@ class TradValidator < ValidatorBase
           {key: "File name", value: @anno_file},
           {key: "Location", value: "Line: #{lines.map{|row| row[:line_no].to_s}.join(", ")}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     end
     ret
@@ -1930,8 +1899,7 @@ class TradValidator < ValidatorBase
             {key: "Location", value: "Line: #{line_no}"},
             {key: "Message", value: message}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -1967,8 +1935,7 @@ class TradValidator < ValidatorBase
             {key: "File name", value: @anno_file},
             {key: "Location", value: "Line: #{location_list.sort.map{|line_no| line_no.to_s}.join(", ")}"}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
         end
       end
     end
@@ -2060,8 +2027,7 @@ class TradValidator < ValidatorBase
           {key: "File name", value: @anno_file},
           {key: "Location", value: "Line: #{row[:line_no]}"}
         ]
-        error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-        @error_list.push(error_hash)
+        add_error(rule_code, annotation)
       end
     }
     ret
@@ -2092,8 +2058,7 @@ class TradValidator < ValidatorBase
               {key: "File name", value: @anno_file},
               {key: "Location", value: "Line: #{row[:line_no]}"}
           ]
-          error_hash = CommonUtils::error_obj(@validation_config["rule" + rule_code], @data_file, annotation)
-          @error_list.push(error_hash)
+          add_error(rule_code, annotation)
           ret = false
         end
       end


### PR DESCRIPTION
## Summary
Every rule check across the validators ended in the same two lines:

\`\`\`ruby
error_hash = CommonUtils::error_obj(@validation_config[\"rule\" + rule_code], @data_file, annotation [, true|false])
@error_list.push(error_hash)
\`\`\`

That is **173 occurrences across 13 files**. Replace with two helpers on \`ValidatorBase\`:

\`\`\`ruby
def add_error(rule_code, annotation, auto_annotation: false, source: @data_file)
  add_raw_error(@validation_config[\"rule\" + rule_code], annotation,
                auto_annotation: auto_annotation, source: source)
end

def add_raw_error(rule, annotation, auto_annotation: false, source: @data_file)
  error = CommonUtils.error_obj(rule, source, annotation, auto_annotation)
  @error_list.push(error)
  error
end
\`\`\`

\`add_error\` covers the 173 common-case sites. \`add_raw_error\` is for the trad sites where the rule hash comes from \`ddbj_parser_rule(msg)\` or \`@conf[:validation_parser_config]\` instead of \`@validation_config\`.

Call sites collapse:

\`\`\`ruby
add_error(rule_code, annotation)
add_error(rule_code, annotation, auto_annotation: true)
add_error(rule_code, annotation, source: @anno_file)              # trad
add_error(rule_code, annotation, source: \"#{@anno_file}, #{@seq_file}\")
add_raw_error(ddbj_parser_rule(msg), annotation, source: \"#{@anno_file}, #{@seq_file}\")
\`\`\`

The trad sites that branched on whether \`@conf[:validation_parser_config][\"rule\" + parser_rule_code]\` exists collapse from 6 lines to 2:

\`\`\`ruby
rule = @conf[:validation_parser_config][\"rule\" + parser_rule_code] || ddbj_parser_rule(msg)
add_raw_error(rule, annotation, source: \"#{@anno_file}, #{@seq_file}\")
\`\`\`

The helpers return the pushed hash so the six \`bioproject_tsv\` sites that toggle \`:external\` after the push lose their \`error_hash\` local cleanly:

\`\`\`ruby
error = add_error(rule_code, annotation)
error[:external] = true if level == \"error_internal_ignore\"
\`\`\`

## Other small changes picked up

- \`biosample_validator.rb\`'s ad-hoc auto-annotation detection collapsed to \`annotation.any? { it[:is_auto_annotation] }\` (Ruby 3.4 implicit block param). 
- \`combination_validator.rb\`'s \`@dra_validation_config\` / \`:dra_validation_config\` renamed to the conventional \`@validation_config\` / \`:validation_config\`. CombinationValidator only ever deals with DRA rules, so the \`dra_\` prefix added no information and was the only thing keeping these 5 call sites out of the helper.
- \`biosample_validator.rb\`'s two literal-rule sites (\`@validation_config[\"ruleBS_R0140\"]\`, \`[\"ruleBS_R0141\"]\`) folded into the helper by passing the rule code as a string literal: \`add_error(\"BS_R0140\", [...])\`.
- \`CommonUtils.error_obj_override\` had no callers anywhere on main; deleted the definition.

## Sites left untransformed

Three \`excel2tsv.rb\` sites still call \`CommonUtils.error_obj\` directly: Excel2Tsv is not a ValidatorBase subclass and one of those three sites assembles the error into a fresh return hash rather than pushing into \`@error_list\`, so a local helper would only collapse 2 of the 3 — not worth a separate helper.

## Stats
14 files touched, **+209 / −401 (−192 lines)**. Test suite unchanged: **324 runs / 2600 assertions / 0 failures / 0 errors / 1 pre-existing skip**.

## Phase 3 (separate PR)
The \`result = true; ... result = false; ... result\` pattern in 100+ validator methods → early-return rewrite. That one needs per-method review, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)