### PR TITLE
Replace CommonUtils.blank? with Active Support's Object#blank?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "activesupport"
 gem "csv"
 gem "dotenv"
 gem "json-schema"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -14,6 +29,9 @@ GEM
     dotenv (3.1.8)
     drb (2.2.3)
     hashdiff (1.2.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    json (2.19.4)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -76,6 +94,7 @@ GEM
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
+    securerandom (0.4.1)
     sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
@@ -93,6 +112,9 @@ GEM
     time (0.4.1)
       date
     timeout (0.6.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.1.1)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -103,6 +125,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport
   csv
   dotenv
   json-schema

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -158,7 +158,7 @@ class BioProjectTsvValidator < ValidatorBase
 
     ### organismの検証とtaxonomy_idの確定
     input_taxid_with_pos =  @tsv_validator.field_value_with_position(bp_data, "taxonomy_id", 0)
-    if input_taxid_with_pos.nil? || CommonUtils::blank?(input_taxid_with_pos[:value]) #taxonomy_idの記述がない
+    if input_taxid_with_pos.nil? || input_taxid_with_pos[:value].blank? #taxonomy_idの記述がない
       taxonomy_id = OrganismValidator::TAX_INVALID #tax_idを使用するルールをスキップさせるために無効値をセット　
     else
       taxonomy_id = input_taxid_with_pos[:value]
@@ -219,7 +219,7 @@ class BioProjectTsvValidator < ValidatorBase
     title_value       = @tsv_validator.field_value(data, "title",       0)
     description_value = @tsv_validator.field_value(data, "description", 0)
     # どちらかが空白なら比較しない (他でエラーになる)
-    return true if CommonUtils.blank?(title_value) || CommonUtils.blank?(description_value)
+    return true if title_value.blank? || description_value.blank?
     return true unless title_value == description_value
 
     annotation = [
@@ -245,7 +245,7 @@ class BioProjectTsvValidator < ValidatorBase
     return true if pubmed_id_list.nil?
     common = CommonUtils.new
     pubmed_id_list.each do |pubmed_id|
-      unless CommonUtils.blank?(pubmed_id)
+      unless pubmed_id.blank?
         unless common.exist_pubmed_id?(pubmed_id.to_s)
           annotation = [
            {key: "Field name", value: "pubmed_id"},
@@ -270,7 +270,7 @@ class BioProjectTsvValidator < ValidatorBase
   #
   def invalid_umbrella_project(rule_code, data)
     bioproject_accession = @tsv_validator.field_value(data, "umbrella_bioproject_accession", 0)
-    return true if CommonUtils.blank?(bioproject_accession)
+    return true if bioproject_accession.blank?
     return true if @db_validator.umbrella_project?(bioproject_accession)
 
     annotation = [
@@ -296,11 +296,11 @@ class BioProjectTsvValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, taxonomy_id, organism_name, sample_scope)
-    return nil if CommonUtils::blank?(sample_scope)
+    return nil if sample_scope.blank?
     result = true
 
     unless sample_scope.downcase == "multiisolate" # multiの場合は無視
-      if CommonUtils::blank?(organism_name) || CommonUtils::null_value?(organism_name) # organismの記載がない
+      if organism_name.blank? || CommonUtils::null_value?(organism_name) # organismの記載がない
         result = false
         annotation = [
           {key: "organism", value: ""},
@@ -308,7 +308,7 @@ class BioProjectTsvValidator < ValidatorBase
           {key: "Message", value: "When sample_scope is '#{sample_scope}', organism is required."}
         ]
         add_error(rule_code, annotation)
-      elsif !(CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID)
+      elsif !(taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID)
         result = @org_validator.is_infraspecific_rank(taxonomy_id)
         if result == false
           annotation = [
@@ -334,8 +334,8 @@ class BioProjectTsvValidator < ValidatorBase
   # true/false
   #
   def metagenome_or_environmental (rule_code, taxonomy_id, organism_name, sample_scope)
-    return nil  if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
-    return nil  if CommonUtils::blank?(sample_scope)
+    return nil  if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil  if sample_scope.blank?
     return true unless sample_scope.downcase == "environment"
 
     # tax_id がmetagenome配下かどうか
@@ -367,10 +367,10 @@ class BioProjectTsvValidator < ValidatorBase
   # true/false
   #
   def taxonomy_name_and_id_not_match (rule_code, taxonomy_id, organism_name)
-    return nil if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
-    return nil if (CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID) && CommonUtils::blank?(organism_name) # BPの場合はorganism nameは必須でない(Multiisolateの場合)のでtax_id共にnilならチェックしない
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if (taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID) && organism_name.blank? # BPの場合はorganism nameは必須でない(Multiisolateの場合)のでtax_id共にnilならチェックしない
 
-    organism_name = "" if CommonUtils::blank?(organism_name)
+    organism_name = "" if organism_name.blank?
     organism_name.chomp.strip!
     scientific_name = @org_validator.get_organism_name(taxonomy_id)
     return true if !scientific_name.nil? && scientific_name == organism_name
@@ -400,8 +400,8 @@ class BioProjectTsvValidator < ValidatorBase
   # true/false
   #
   def taxonomy_error_warning (rule_code, organism_with_pos, taxid_with_pos)
-    return nil if CommonUtils::blank?(organism_with_pos) #organismの記載無し
-    organism_with_pos[:value] = "" if CommonUtils::blank?(organism_with_pos[:value])
+    return nil if organism_with_pos.blank? #organismの記載無し
+    organism_with_pos[:value] = "" if organism_with_pos[:value].blank?
     result = false #このメソッドが呼び出されている時点でfalse
 
     unless organism_with_pos[:value] == ""

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -99,7 +99,7 @@ class BioProjectValidator < ValidatorBase
       @taxid_path = "//Organism/@taxID"
       @orgname_path = "//Organism/OrganismName"
       input_taxid = get_node_text(project_node, @taxid_path)
-      if input_taxid.nil? || CommonUtils::blank?(input_taxid) #taxonomy_idの記述がない
+      if input_taxid.nil? || input_taxid.blank? #taxonomy_idの記述がない
         taxonomy_id = OrganismValidator::TAX_INVALID #tax_idを使用するルールをスキップさせるために無効値をセット　
       else
         taxonomy_id = input_taxid
@@ -362,7 +362,7 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, project_label, taxonomy_id, organism_name, project_node, line_num)
-    return nil if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
     result = true
     primary_taxid = project_node.xpath("//Project/ProjectType/ProjectTypeSubmission")
     multispecies = project_node.xpath("//Project/ProjectType/ProjectTypeSubmission/Target[@sample_scope='eMultispecies']")
@@ -393,7 +393,7 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def metagenome_or_environmental (rule_code, project_label, taxonomy_id, organism_name, project_node, line_num)
-    return nil if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
 
     # eEnvironment でなければチェックしない
     environment = project_node.xpath("//Project/ProjectType/ProjectTypeSubmission/Target[@sample_scope='eEnvironment']")
@@ -429,9 +429,9 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def taxonomy_name_and_id_not_match (rule_code, project_label, taxonomy_id, organism_name, project_node, line_num)
-    return nil if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
 
-    organism_name   = "" if CommonUtils::blank?(organism_name)
+    organism_name   = "" if organism_name.blank?
     scientific_name = @org_validator.get_organism_name(taxonomy_id)
     return true if !scientific_name.nil? && scientific_name == organism_name
 
@@ -461,7 +461,7 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def taxonomy_error_warning (rule_code, project_label, organism_name, project_node, line_num)
-    organism_name = "" if CommonUtils::blank?(organism_name)
+    organism_name = "" if organism_name.blank?
     result = false
 
     unless organism_name == ""

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -166,21 +166,7 @@ class BioProjectValidator < ValidatorBase
       end
     end
     # いずれの記述もない場合には何番目のprojectであるかを示す
-    if project_name == ""
-      ordinal_num = ""
-      if line_num == 11
-        ordinal_num = "11th"
-      elsif line_num.to_s[-1] == "1"
-        ordinal_num = line_num.to_s + "st"
-      elsif line_num.to_s[-1] == "2"
-        ordinal_num = line_num.to_s + "nd"
-      elsif line_num.to_s[-1] == "3"
-        ordinal_num = line_num.to_s + "rd"
-      else
-        ordinal_num = line_num.to_s + "th"
-      end
-      project_name = ordinal_num + " project"
-    end
+    project_name = "#{line_num.ordinalize} project" if project_name == ""
     project_name
   end
 

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -536,7 +536,7 @@ class BioSampleValidator < ValidatorBase
           else
             attr_name = attribute["key"]
           end
-          #if !(CommonUtils::blank?(attribute["key"]) && CommonUtils::blank?(attribute["value"]))
+          #if !(attribute["key"].blank? && attribute["value"].blank?)
           # 値が空でない属性だけの属性ハッシュ&リストを生成。taxonomy_idは値追加の機会が多いので空値でも属性として保持する
           if biosample["attributes"][attr_name].nil? # 同一属性が出現する場合は、先の記述を優先
             biosample["attributes"][attr_name] = attribute["value"]
@@ -638,7 +638,7 @@ class BioSampleValidator < ValidatorBase
     return if attribute_list.nil?
     missing_attr_list = []
     attribute_list.each do |attr|
-      if CommonUtils::blank?(attr.keys.first) && !CommonUtils::blank?(attr[attr.keys.first]) # keyがなくvalueだけあるもの
+      if attr.keys.first.blank? && attr[attr.keys.first].present? # keyがなくvalueだけあるもの
         missing_attr_list.push(attr)
       end
     end
@@ -707,7 +707,7 @@ class BioSampleValidator < ValidatorBase
   def missing_package_information (rule_code, sample_name, biosample_data, line_num)
     return nil if biosample_data.nil?
 
-    if !CommonUtils::blank?(biosample_data["package"])
+    if biosample_data["package"].present?
       true
     else
       annotation = [
@@ -730,7 +730,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def unknown_package (rule_code, sample_name, package_name, package_version, line_num)
-    return nil if CommonUtils::blank?(package_name)
+    return nil if package_name.blank?
 
     #あればキャッシュを使用
     if @cache.nil? || @cache.check(ValidatorCache::UNKNOWN_PACKAGE, package_name).nil?
@@ -852,7 +852,7 @@ class BioSampleValidator < ValidatorBase
 
     sample_attr.each do |attr_name, attr_value|
       if mandatory_attr_list.include?(attr_name)
-        if CommonUtils::blank?(attr_value)
+        if attr_value.blank?
           missing_attr_names.push(attr_name)
         end
       end
@@ -890,7 +890,7 @@ class BioSampleValidator < ValidatorBase
       exist_attr_list = []
       attr_set.each do |mandatory_attr_name|
         sample_attr.each do |attr_name, attr_value|
-          if mandatory_attr_name == attr_name && !CommonUtils::blank?(attr_value)
+          if mandatory_attr_name == attr_name && attr_value.present?
             exist_attr_list.push(attr_name)
           end
         end
@@ -954,7 +954,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def attribute_value_not_in_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil  if attr_name.blank? || CommonUtils::null_value?(attr_val)
 
     result =  true
     if !cv_attr[attr_name].nil? # CVを使用する属性か
@@ -1009,7 +1009,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_attribute_value_for_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil  if attr_name.blank? || CommonUtils::null_value?(attr_val)
 
     # CVを使用しない属性か、CVリストに値があれば OK
     return true if cv_attr[attr_name].nil? || cv_attr[attr_name].include?(attr_val)
@@ -1037,7 +1037,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_publication_identifier (rule_code, sample_name, attr_name, attr_val, ref_attr, line_num)
-    return nil  if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil  if attr_name.blank? || CommonUtils::null_value?(attr_val)
 
     common = CommonUtils.new
     result =  true
@@ -1550,7 +1550,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def package_versus_organism (rule_code, sample_name, taxonomy_id, package_name, organism, line_num)
-    return nil if CommonUtils::blank?(package_name) || CommonUtils::null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if package_name.blank? || CommonUtils::null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
 
     #あればキャッシュを使用
     cache_key = ValidatorCache::create_key(taxonomy_id, package_name)
@@ -1593,7 +1593,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def sex_for_bacteria (rule_code, sample_name, taxonomy_id, sex, organism, line_num)
-    return nil if CommonUtils::blank?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID || CommonUtils::null_value?(sex)
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID || CommonUtils::null_value?(sex)
 
     ret = true
     bac_vir_linages = [OrganismValidator::TAX_BACTERIA, OrganismValidator::TAX_VIRUSES]
@@ -1782,7 +1782,7 @@ class BioSampleValidator < ValidatorBase
   # line_num
   # ==== Return
   def invalid_missing_value(rule_code, sample_name, attr_name, attr_val, null_accepted_list, null_not_recommended_list, package_attr_list, attr_no, line_num)
-    return nil if CommonUtils::blank?(attr_val)
+    return nil if attr_val.blank?
     result = true
 
     unless package_attr_list.nil?
@@ -1856,7 +1856,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime_format (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num )
-    return nil if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil if attr_name.blank? || CommonUtils::null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) #日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
     return nil if attr_name == "collection_date" && (CommonUtils::null_not_recommended_value?(attr_val))
@@ -1912,7 +1912,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num )
-    return nil if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil if attr_name.blank? || CommonUtils::null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) #日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
     return nil if attr_name == "collection_date" && (CommonUtils::null_not_recommended_value?(attr_val))
@@ -1949,10 +1949,10 @@ class BioSampleValidator < ValidatorBase
   #
   def special_character_included (rule_code, sample_name, attr_name, attr_val, special_chars, target, line_num)
     if target == "attr_name" #属性名の検証
-      return nil if CommonUtils::blank?(attr_name)
+      return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == "attr_value" #属性値の検証
-      return nil if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+      return nil if attr_name.blank? || CommonUtils::null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -2025,9 +2025,9 @@ class BioSampleValidator < ValidatorBase
     if taxon_values.size == uniq_taxon_values.size
       return true
     else
-      organism = "" if CommonUtils::blank?(organism)
-      host = "" if CommonUtils::blank?(host)
-      isolation_source = "" if CommonUtils::blank?(isolation_source)
+      organism = "" if organism.blank?
+      host = "" if host.blank?
+      isolation_source = "" if isolation_source.blank?
       annotation = [
         {key: "Sample name", value: sample_name},
         {key: "organism", value: organism},
@@ -2055,10 +2055,10 @@ class BioSampleValidator < ValidatorBase
   #
   def invalid_data_format (rule_code, sample_name, attr_name, attr_val, target, attr_no, line_num)
     if target == "attr_name" #属性名の検証
-      return nil if CommonUtils::blank?(attr_name)
+      return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == "attr_value" #属性値の検証
-      return nil if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+      return nil if attr_name.blank? || CommonUtils::null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -2118,7 +2118,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_ascii_attribute_value (rule_code, sample_name, attr_name, attr_val, line_num)
-    return nil  if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil  if attr_name.blank? || CommonUtils::null_value?(attr_val)
     return true if attr_val.ascii_only?
 
     # 属性値のどこにnon ascii文字があるか示すメッセージを作成
@@ -2145,7 +2145,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def duplicated_sample_title_in_this_submission (rule_code, biosample_list)
-    return nil if CommonUtils::blank?(biosample_list)
+    return nil if biosample_list.blank?
 
     result = true
     biosample_list_lite = []
@@ -2317,7 +2317,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_integer_attribute_value (rule_code, sample_name, attr_name, attr_val, int_attr, line_num)
-    return nil  if CommonUtils::blank?(attr_name) || CommonUtils::null_value?(attr_val)
+    return nil  if attr_name.blank? || CommonUtils::null_value?(attr_val)
     # 整数型の属性であり有効な入力値がある場合だけチェック
     return true unless int_attr.include?(attr_name)
 
@@ -2346,7 +2346,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def duplicate_sample_names(rule_code, biosample_list)
-    return nil if CommonUtils::blank?(biosample_list)
+    return nil if biosample_list.blank?
     result = true
 
     # 同一ファイル内での重複チェック. 同じsubmissionは1ファイル内に列挙されていることを前提とする
@@ -2697,7 +2697,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_taxonomy_for_genome_sample (rule_code, sample_name, package_name, taxonomy_id, organism, line_num)
-    return nil if CommonUtils::blank?(package_name) || CommonUtils::null_value?(organism)
+    return nil if package_name.blank? || CommonUtils::null_value?(organism)
     result = true
     if package_name.start_with?("MIGS.ba") || package_name.start_with?("MIGS.eu")
       # "sp."終わり、または"xxx sp. (in: yyy)", "xxx sp. (ex yyy)"であればエラー seealso: https://ddbj-dev.atlassian.net/browse/VALIDATOR-14
@@ -3095,7 +3095,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def cov2_package_versus_organism (rule_code, sample_name, package_name, organism, line_num)
-    return nil if CommonUtils::blank?(package_name) || CommonUtils::blank?(organism)
+    return nil if package_name.blank? || organism.blank?
     ret = true
     if package_name.downcase.start_with?("sars-cov-2.") # SARS-CoV-2.clとSARS-CoV-2.wwsurvの場合だけエラーにする
       ret = false
@@ -3346,7 +3346,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def null_value_for_infraspecific_identifier_error (rule_code, sample_name, sample_attr, package_name, line_num)
-    return nil if CommonUtils::blank?(package_name)
+    return nil if package_name.blank?
     # 設定ファイルに書くか？
     package_vs_attr_settings = {
       "MIGS.ba" => ["strain"],
@@ -3376,7 +3376,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def null_value_for_infraspecific_identifier_warning (rule_code, sample_name, sample_attr, package_name, line_num)
-    return nil if CommonUtils::blank?(package_name)
+    return nil if package_name.blank?
     # 設定ファイルに書くか？
     package_vs_attr_settings = {
       "Microbe" => ["strain", "isolate"]
@@ -3399,7 +3399,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def null_value_for_infraspecific_identifier (rule_code, sample_name, sample_attr, package_name, package_vs_attr_settings, line_num)
-    return nil if CommonUtils::blank?(package_name)
+    return nil if package_name.blank?
     ret = true
     mandatory_attr_list_to_message = nil
     package_vs_attr_settings.each do |package_prefix, mandatory_attr_list|
@@ -3443,7 +3443,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_identical_identifiers_among_organism_strain_isolate (rule_code, sample_name, package_name, organism, strain, isolate, line_num)
-    return nil if CommonUtils::blank?(package_name) || CommonUtils::null_value?(organism)
+    return nil if package_name.blank? || CommonUtils::null_value?(organism)
     result = true
     if package_name.start_with?("MIGS.ba")
       keywords = ["sp.", "bacterium", "archaeon"]

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -2065,15 +2065,12 @@ class BioSampleValidator < ValidatorBase
     end
 
     result = true
-    replaced.strip!  #セル内の前後の空白文字を除去
-    replaced.gsub!(/\t/, " ") #セル内部のタブを空白1個に
-    replaced.gsub!(/\s+/, " ") #二個以上の連続空白を１個に
-    replaced.gsub!(/(\r\n|\r|\n)/, " ") #セル内部の改行を空白1個に
-    #セル内の最初と最後が ' or " で囲われていたら削除
+    # 前後の空白除去 + タブ/改行/連続空白を 1 個の空白に圧縮
+    replaced = replaced.squish
+    # セル内の最初と最後が ' or " で囲われていたら削除 → 再度 strip
     if (replaced =~ /^"/ && replaced =~ /"$/) || (replaced =~ /^'/ && replaced =~ /'$/)
-      replaced = replaced[1..-2]
+      replaced = replaced[1..-2].strip
     end
-    replaced.strip!  #引用符を除いた後にセル内の前後の空白文字をもう一度除去
     if target == "attr_name" && replaced != attr_name #属性名のAuto-annotationが必要
       annotation = [
         {key: "Sample name", value: sample_name},

--- a/lib/validator/common/common_utils.rb
+++ b/lib/validator/common/common_utils.rb
@@ -3,7 +3,9 @@ require 'net/http'
 require 'net/https'
 require 'net/ftp'
 require 'date'
+require 'active_support/core_ext/integer/inflections'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/string/filters'
 
 class CommonUtils
   @@AUTO_ANNOTAION_MSG = "An automatically-generated correction will be applied."

--- a/lib/validator/common/common_utils.rb
+++ b/lib/validator/common/common_utils.rb
@@ -3,6 +3,7 @@ require 'net/http'
 require 'net/https'
 require 'net/ftp'
 require 'date'
+require 'active_support/core_ext/object/blank'
 
 class CommonUtils
   @@AUTO_ANNOTAION_MSG = "An automatically-generated correction will be applied."
@@ -171,18 +172,6 @@ class CommonUtils
     else
       annotation[:suggested_value].first
     end
-  end
-
-  #
-  # 引数がnilか空白文字であればtrueを返す
-  #
-  # ==== Args
-  # value: 検査する値
-  # ==== Return
-  # true/false
-  #
-  def self.blank?(value)
-    value.nil? || value.to_s.strip.empty?
   end
 
   #

--- a/lib/validator/common/tsv_field_validator.rb
+++ b/lib/validator/common/tsv_field_validator.rb
@@ -182,16 +182,12 @@ class TsvFieldValidator
   # これはCOMMONでもよいかも
   def replace_invalid_data(value)
     return nil if value.nil?
-    replaced = value.dup
-    replaced.strip!  #セル内の前後の空白文字を除去
-    replaced.gsub!(/\t/, " ") #セル内部のタブを空白1個に
-    replaced.gsub!(/\s+/, " ") #二個以上の連続空白を１個に
-    replaced.gsub!(/(\r\n|\r|\n)/, " ") #セル内部の改行を空白1個に
-    #セル内の最初と最後が ' or " で囲われていたら削除
+    # 前後の空白除去 + タブ/改行/連続空白を 1 個の空白に圧縮
+    replaced = value.squish
+    # セル内の最初と最後が ' or " で囲われていたら削除 → 再度 strip
     if (replaced =~ /^"/ && replaced =~ /"$/) || (replaced =~ /^'/ && replaced =~ /'$/)
-      replaced = replaced[1..-2]
+      replaced = replaced[1..-2].strip
     end
-    replaced.strip!  #引用符を除いた後にセル内の前後の空白文字をもう一度除去
     replaced
   end
 

--- a/lib/validator/common/tsv_field_validator.rb
+++ b/lib/validator/common/tsv_field_validator.rb
@@ -47,13 +47,13 @@ class TsvFieldValidator
   def invalid_value_input(data, mode=nil)
     invalid_list = []
     data.each_with_index do |row, field_idx|
-      if CommonUtils.blank?(row["key"]) || row["key"].start_with?("#")
+      if row["key"].blank? || row["key"].start_with?("#")
         next if row["values"].nil?
         value_list = row["values"].uniq.compact
         unless (value_list == [] || value_list == [""])
           if mode == "comment_line" && row["key"].start_with?("#")
             invalid_list.push({field_name: row["key"], value: row["values"].to_s, field_idx: field_idx})
-          elsif (mode.nil? || mode == "") && CommonUtils.blank?(row["key"])
+          elsif (mode.nil? || mode == "") && row["key"].blank?
             invalid_list.push({field_name: "", value: row["values"].to_s, field_idx: field_idx})
           end
         end
@@ -99,7 +99,7 @@ class TsvFieldValidator
     data.each_with_index do |row, field_idx|
       next if mandatory_field_list.include?(row["key"]) # ここではoptional fieldのみ置換する
       row["values"].each_with_index do |value, value_idx|
-        next if CommonUtils.blank?(value)
+        next if value.blank?
         null_accepted_size = null_accepted_list.select{|refexp| value =~ /#{refexp}/i }.size
         null_not_recomm_size = null_not_recommended_list.select {|refexp| value =~ /^(#{refexp})$/i }.size
         if (null_accepted_size + null_not_recomm_size) > 0
@@ -226,7 +226,7 @@ class TsvFieldValidator
     data.each_with_index do |row, field_idx|
       next if cv_check_field[row["key"]].nil? || row["values"].nil?
       row["values"].each_with_index do |value, value_idx|
-        next if CommonUtils.blank?(value)
+        next if value.blank?
         unless cv_check_field[row["key"]].first["value_list"].include?(value) #CVに含まれていない値
           if null_accepted_list.include?(value) # null値での記載
             if not_allow_null_field_list.include?(row["key"]) # null値の入力が許容されていなければNG
@@ -287,7 +287,7 @@ class TsvFieldValidator
     data.each_with_index do |row, field_idx|
       next if field_format[row["key"]].nil? || row["values"].nil?
       row["values"].each_with_index do |value, value_idx|
-        next if CommonUtils.blank?(value) # is null val?
+        next if value.blank? # is null val?
         format_conf = field_format[row["key"]].first
         if !format_conf["regex"].nil? # 正規表現によるチェック
           unless CommonUtils.format_check_with_regexp(value, format_conf["regex"])
@@ -354,7 +354,7 @@ class TsvFieldValidator
       (0..max_value_index).each do |value_idx|
         group_field_values = {}
         group["field_list"].each do |field_name|
-          unless CommonUtils.blank?(field_value(data, field_name, value_idx))
+          unless field_value(data, field_name, value_idx).blank?
             group_field_values[field_name] = field_value(data, field_name, value_idx)
           end
         end
@@ -505,7 +505,7 @@ class TsvFieldValidator
     CSV.open(output_file, "w", col_sep: "\t") do |csv|
       input_data.each do |row|
         row_data = []
-        if CommonUtils.blank?(row["key"]) && (CommonUtils.blank?(row["values"]) || row["values"] == [])
+        if row["key"].blank? && (row["values"].blank? || row["values"] == [])
           row_data = [nil]
         else
           row_data.push(row["key"])

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -574,7 +574,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def check_by_jparser(rule_code, anno_file_path, seq_file_path)
-    return nil if CommonUtils::blank?(anno_file_path) || CommonUtils::blank?(seq_file_path)
+    return nil if anno_file_path.blank? || seq_file_path.blank?
     return if @use_parser.nil? || @use_parser == false
     ret = true
 
@@ -634,7 +634,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def check_by_transchecker(rule_code, anno_file_path, seq_file_path)
-    return nil if CommonUtils::blank?(anno_file_path) || CommonUtils::blank?(seq_file_path)
+    return nil if anno_file_path.blank? || seq_file_path.blank?
     return if @use_parser.nil? || @use_parser == false
     ret = true
 
@@ -687,7 +687,7 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def check_by_agpparser(rule_code, anno_file_path, seq_file_path, agp_file_path)
-    return nil if CommonUtils::blank?(anno_file_path) || CommonUtils::blank?(seq_file_path) || CommonUtils::blank?(agp_file_path)
+    return nil if anno_file_path.blank? || seq_file_path.blank? || agp_file_path.blank?
     return if @use_parser.nil? || @use_parser == false
     ret = true
 

--- a/test/lib/validator/bioproject_validator_test.rb
+++ b/test/lib/validator/bioproject_validator_test.rb
@@ -50,7 +50,7 @@ class TestBioProjectValidator < Minitest::Test
   def get_input_taxid (project_node)
     taxonomy_id = OrganismValidator::TAX_INVALID
     input_taxid = @validator.get_node_text(project_node,  "//Organism/@taxID")
-    unless CommonUtils::blank?(input_taxid) #taxonomy_idの記述があれば
+    unless input_taxid.blank? #taxonomy_idの記述があれば
       taxonomy_id = input_taxid
     end
     taxonomy_id
@@ -59,7 +59,7 @@ class TestBioProjectValidator < Minitest::Test
   def get_input_organism_name (project_node)
     organism_name = ""
     input_oganism_name = @validator.get_node_text(project_node,  "//Organism/OrganismName")
-    unless CommonUtils::blank?(input_oganism_name) #organism_nameの記述があれば
+    unless input_oganism_name.blank? #organism_nameの記述があれば
       organism_name = input_oganism_name
     end
     organism_name


### PR DESCRIPTION
## Summary
\`CommonUtils.blank?\` was a five-line reimplementation of a well-known Rails idiom:

\`\`\`ruby
def self.blank?(value)
  value.nil? || value.to_s.strip.empty?
end
\`\`\`

Active Support ships the same thing on every object, plus the \`present?\` inverse. Requiring \`active_support/core_ext/object/blank\` lets us drop the helper and collapse the 72 call sites into plain \`x.blank?\` / \`x.present?\`.

## Changes

- \`Gemfile\` / \`Gemfile.lock\`: add \`activesupport\` (pulls in \`concurrent-ruby\`, ~2 gems).
- \`lib/validator/common/common_utils.rb\`: \`require 'active_support/core_ext/object/blank'\` at the top, delete the \`CommonUtils.blank?\` method.
- 9 files, mechanical rewrites:
  - 69 × \`CommonUtils.blank?(x)\` / \`CommonUtils::blank?(x)\` → \`x.blank?\`
  - 3 × \`!CommonUtils.blank?(x)\` → \`x.present?\`

## Sanity check
One nested-paren site (\`CommonUtils.blank?(field_value(...))\`) needed a hand edit because the bulk regex doesn't recurse into inner parens. The test suite caught it cleanly: \`ArgumentError: wrong number of arguments (given 1, expected 0)\` — which actually proved that \`Object#blank?\` had successfully shadowed the now-deleted helper, since \`CommonUtils\` itself inherited the new \`blank?\` through the \`Object\` mixin and was being called as \`CommonUtils.blank?\` (no-arg).

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` — **324 runs / 2600 assertions / 0 failures / 0 errors / 1 pre-existing skip**.

## Next (separate PR)
Phase 2 of the nullability cleanup: convert the INSDC-specific \`CommonUtils.null_value?\` / \`null_not_recommended_value?\` / \`meaningless_value?\` family into a Refinement on \`String\` + \`NilClass\` so call sites can write \`value.null_value?\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)