### PR TITLE
Prefer require_relative over File.dirname(__FILE__) + string

### DIFF
--- a/lib/package/package.rb
+++ b/lib/package/package.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'json'
 require 'erb'
 require 'logger'
-require File.dirname(__FILE__) + "/../validator/common/sparql_base.rb"
-require File.dirname(__FILE__) + "/../validator/common/insdc_nullability.rb"
+require_relative "../validator/common/sparql_base"
+require_relative "../validator/common/insdc_nullability"
 
 class Package < SPARQLBase
 

--- a/lib/submitter/bioproject_submitter.rb
+++ b/lib/submitter/bioproject_submitter.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 class BioProjectSubmitter < SubmitterBase
   BIOPROJECT_DB_NAME = "bioproject"

--- a/lib/submitter/biosample_submitter.rb
+++ b/lib/submitter/biosample_submitter.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 class BioSampleSubmitter < SubmitterBase
   BIOSAMPLE_DB_NAME = "biosample"

--- a/lib/submitter/dra_submitter.rb
+++ b/lib/submitter/dra_submitter.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 class DraSubmitter < SubmitterBase
   DRA_DB_NAME = "drmdb"

--- a/lib/submitter/submitter.rb
+++ b/lib/submitter/submitter.rb
@@ -1,9 +1,9 @@
 require 'logger'
 require 'nokogiri'
 require 'yaml'
-require File.dirname(__FILE__) + "/biosample_submitter.rb"
-require File.dirname(__FILE__) + "/bioproject_submitter.rb"
-require File.dirname(__FILE__) + "/dra_submitter.rb"
+require_relative "biosample_submitter"
+require_relative "bioproject_submitter"
+require_relative "dra_submitter"
 
 class Submitter
   # constructor

--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -3,9 +3,9 @@ require 'json'
 require 'erb'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
 
 #
 # A class for DRA analysis validation

--- a/lib/validator/auto_annotator/auto_annotator_json.rb
+++ b/lib/validator/auto_annotator/auto_annotator_json.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'fileutils'
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 #
 # A class for Auto-annotation. JSON file base.

--- a/lib/validator/auto_annotator/auto_annotator_tsv.rb
+++ b/lib/validator/auto_annotator/auto_annotator_tsv.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 #
 # A class for Auto-annotation. TSV file base.

--- a/lib/validator/auto_annotator/auto_annotator_xml.rb
+++ b/lib/validator/auto_annotator/auto_annotator_xml.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'nokogiri'
 require 'fileutils'
 
-require File.dirname(__FILE__) + "/base.rb"
+require_relative "base"
 
 #
 # A class for Auto-annotation. XML file base.

--- a/lib/validator/base.rb
+++ b/lib/validator/base.rb
@@ -1,8 +1,8 @@
 require 'yaml'
 require 'json'
 require 'json-schema'
-require File.dirname(__FILE__) + "/common/error_builder.rb"
-require File.dirname(__FILE__) + "/common/ncbi_eutils.rb"
+require_relative "common/error_builder"
+require_relative "common/ncbi_eutils"
 
 class ValidatorBase
 

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -5,12 +5,12 @@ require 'ostruct'
 require 'date'
 require 'net/http'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
-require File.dirname(__FILE__) + "/common/organism_validator.rb"
-require File.dirname(__FILE__) + "/common/tsv_field_validator.rb"
-require File.dirname(__FILE__) + "/common/file_parser.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
+require_relative "common/organism_validator"
+require_relative "common/tsv_field_validator"
+require_relative "common/file_parser"
 
 #
 # A class for BioProject validation

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -6,10 +6,10 @@ require 'date'
 require 'net/http'
 require 'nokogiri'
 require 'active_support/core_ext/integer/inflections'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
-require File.dirname(__FILE__) + "/common/organism_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
+require_relative "common/organism_validator"
 
 #
 # A class for BioProject validation

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -5,18 +5,18 @@ require 'ostruct'
 require 'date'
 require 'net/http'
 require 'active_support/core_ext/string/filters'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/coll_dump.rb"
-require File.dirname(__FILE__) + "/common/date_format.rb"
-require File.dirname(__FILE__) + "/common/geolocation.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
-require File.dirname(__FILE__) + "/common/organism_validator.rb"
-require File.dirname(__FILE__) + "/common/sparql_base.rb"
-require File.dirname(__FILE__) + "/common/validator_cache.rb"
-require File.dirname(__FILE__) + "/common/xml_convertor.rb"
-require File.dirname(__FILE__) + "/common/file_parser.rb"
-require File.dirname(__FILE__) + "/common/tsv_column_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/coll_dump"
+require_relative "common/date_format"
+require_relative "common/geolocation"
+require_relative "common/ddbj_db_validator"
+require_relative "common/organism_validator"
+require_relative "common/sparql_base"
+require_relative "common/validator_cache"
+require_relative "common/xml_convertor"
+require_relative "common/file_parser"
+require_relative "common/tsv_column_validator"
 
 #
 # A class for BioSample validation

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -3,9 +3,9 @@ require 'json'
 require 'erb'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
 
 #
 # A class for validation

--- a/lib/validator/common/excel2tsv.rb
+++ b/lib/validator/common/excel2tsv.rb
@@ -1,7 +1,7 @@
 require 'roo'
 require 'csv'
 require 'fileutils'
-require File.dirname(__FILE__) + "/insdc_nullability.rb"
+require_relative "insdc_nullability"
 
 #
 # A class for convert from excel sheet to tsv files

--- a/lib/validator/common/organism_validator.rb
+++ b/lib/validator/common/organism_validator.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'json'
 require 'erb'
-require File.dirname(__FILE__) + "/sparql_base.rb"
-require File.dirname(__FILE__) + "/insdc_nullability.rb"
+require_relative "sparql_base"
+require_relative "insdc_nullability"
 
 #
 # A class for BioSample validation that is relevant organism

--- a/lib/validator/common/sparql_base.rb
+++ b/lib/validator/common/sparql_base.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'rubygems'
 require 'json'
 require 'erb'
-require File.dirname(__FILE__) + "/sparql.rb"
+require_relative "sparql"
 
 
 # A class for execute sparql query

--- a/lib/validator/common/tsv_column_validator.rb
+++ b/lib/validator/common/tsv_column_validator.rb
@@ -1,5 +1,5 @@
 require 'json'
-require File.dirname(__FILE__) + "/../auto_annotator/auto_annotator_json.rb"
+require_relative "../auto_annotator/auto_annotator_json"
 
 # BioSample/MetaboBank(SDRF)のような一列目に項目名を記述するTSV(あるいはそれをJSONに変換した)形式を処理するクラス
 class TsvColumnValidator

--- a/lib/validator/common/tsv_field_validator.rb
+++ b/lib/validator/common/tsv_field_validator.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'active_support/core_ext/string/filters'
-require File.dirname(__FILE__) + "/../auto_annotator/auto_annotator_json.rb"
+require_relative "../auto_annotator/auto_annotator_json"
 
 # BioProject/MetaboBank(IDF)のような最左列に項目名を記述するTSV(あるいはそれをJSONに変換した)形式を処理するクラス
 class TsvFieldValidator

--- a/lib/validator/common/xml_convertor.rb
+++ b/lib/validator/common/xml_convertor.rb
@@ -4,7 +4,7 @@ require 'erb'
 require 'ostruct'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/../base.rb"
+require_relative "../base"
 
 #
 # XMLの変換処理を行うクラス

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -3,9 +3,9 @@ require 'json'
 require 'erb'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
 
 #
 # A class for DRA experiment validation

--- a/lib/validator/jvar_validator.rb
+++ b/lib/validator/jvar_validator.rb
@@ -6,13 +6,13 @@ require 'date'
 require 'net/http'
 require 'roo'
 require 'sanitize'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/date_format.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
-require File.dirname(__FILE__) + "/common/organism_validator.rb"
-require File.dirname(__FILE__) + "/common/sparql_base.rb"
-require File.dirname(__FILE__) + "/common/validator_cache.rb"
-require File.dirname(__FILE__) + "/common/xml_convertor.rb"
+require_relative "base"
+require_relative "common/date_format"
+require_relative "common/ddbj_db_validator"
+require_relative "common/organism_validator"
+require_relative "common/sparql_base"
+require_relative "common/validator_cache"
+require_relative "common/xml_convertor"
 
 #
 # A class for JVar validation

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -5,10 +5,10 @@ require 'ostruct'
 require 'date'
 require 'net/http'
 require 'json-schema'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/tsv_field_validator.rb"
-require File.dirname(__FILE__) + "/common/file_parser.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/tsv_field_validator"
+require_relative "common/file_parser"
 
 #
 # A class for MetaboBank IDF validation

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -5,10 +5,10 @@ require 'ostruct'
 require 'date'
 require 'net/http'
 require 'json-schema'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/tsv_column_validator.rb"
-require File.dirname(__FILE__) + "/common/file_parser.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/tsv_column_validator"
+require_relative "common/file_parser"
 
 #
 # A class for MetaboBank SDRF validation

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -3,9 +3,9 @@ require 'json'
 require 'erb'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
 
 #
 # A class for DRA run validation

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -3,9 +3,9 @@ require 'json'
 require 'erb'
 require 'date'
 require 'nokogiri'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/insdc_nullability.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
+require_relative "base"
+require_relative "common/insdc_nullability"
+require_relative "common/ddbj_db_validator"
 
 #
 # A class for DRA submission validation

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -3,12 +3,12 @@ require 'json'
 require 'erb'
 require 'date'
 require 'http'
-require File.dirname(__FILE__) + "/base.rb"
-require File.dirname(__FILE__) + "/common/date_format.rb"
-require File.dirname(__FILE__) + "/common/ddbj_db_validator.rb"
-require File.dirname(__FILE__) + "/common/organism_validator.rb"
-require File.dirname(__FILE__) + "/common/sparql_base.rb"
-require File.dirname(__FILE__) + "/common/validator_cache.rb"
+require_relative "base"
+require_relative "common/date_format"
+require_relative "common/ddbj_db_validator"
+require_relative "common/organism_validator"
+require_relative "common/sparql_base"
+require_relative "common/validator_cache"
 
 #
 # A class for Trad validation


### PR DESCRIPTION
## Summary
- 全 27 ファイルの \`require File.dirname(__FILE__) + \"/foo.rb\"\` を \`require_relative \"foo\"\` に置換
- 挙動は同一、ノイズが減って読みやすくなる

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` → 324 runs, 2207 assertions, 0 failures, 0 errors, 36 skips
- [ ] CI 緑を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)