### PR TITLE
Preserve route-provided body in generic error handler

### DIFF
--- a/app/application.rb
+++ b/app/application.rb
@@ -449,8 +449,12 @@ module DDBJValidator
         send_file 'error_not_found.json', root: settings.public_folder, status: 404
       elsif status == 500
         send_file 'error_internal_server_error.json', root: settings.public_folder, status: 500
-      else #other error with rack default message
-        { status: "error", "message": Rack::Utils::HTTP_STATUS_CODES[status] }.to_json
+      else
+        # route がすでに診断用の body を書いていればそれをそのまま返す。
+        # (例: /api/monitoring が 503 + 具体的なエラーメッセージを返すケース)
+        # body が空のときだけ Rack の汎用メッセージにフォールバックする。
+        current_body = [body].flatten.join
+        current_body.empty? ? { status: "error", "message": Rack::Utils::HTTP_STATUS_CODES[status] }.to_json : current_body
       end
     end
 


### PR DESCRIPTION
## Summary
- \`error 400..599\` の catch-all 分岐が route 側の body を Rack の汎用文字列で上書きしていた
- \`/api/monitoring\` が 503 時に返す診断 JSON (\"Error has occurred during monitoring processing. ...\") が \"Service Unavailable\" に潰される原因
- route が既に body を設定していればそれをスルーし、空の時だけ汎用メッセージにフォールバック

## Test plan
- [x] \`bundle exec ruby test/run_all.rb\` → 324 runs, 2207 assertions, 0 failures, 0 errors, 36 skips
- [ ] デプロイ後、\`/api/monitoring\` が失敗時に具体的メッセージを返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)