### PR TITLE
Require ddbj_rdb in all environments via populated YAML defaults

### DIFF
--- a/config/initializers/validator_config.rb
+++ b/config/initializers/validator_config.rb
@@ -1,0 +1,8 @@
+# 起動時に validator 設定の必須項目が揃っているかを fail-fast でチェック。
+# dev/test も含む全環境で必須 (config/validator.yml が ENV.fetch のデフォルトで
+# 必ず populate するので未設定で boot することはない想定)。
+required_db_keys = %i[pg_host pg_port pg_user pg_pass]
+db = Rails.configuration.validator['ddbj_rdb']
+missing = db ? required_db_keys.reject { db.has_key?(it) } : required_db_keys
+
+raise "validator.ddbj_rdb is missing keys: #{missing.join(', ')} (env: #{Rails.env})" if missing.any?

--- a/config/validator.yml
+++ b/config/validator.yml
@@ -17,10 +17,10 @@ development: &dev
   named_graph_uri:
     taxonomy: http://ddbj.nig.ac.jp/ontologies/taxonomy
   ddbj_rdb:
-    pg_host:    <%= ENV['DDBJ_VALIDATOR_APP_POSTGRES_HOST'] %>
-    pg_port:    <%= ENV['DDBJ_VALIDATOR_APP_POSTGRES_PORT'] %>
-    pg_user:    <%= ENV['DDBJ_VALIDATOR_APP_POSTGRES_USER'] %>
-    pg_pass:    <%= ENV['DDBJ_VALIDATOR_APP_POSTGRES_PASSWD'] %>
+    pg_host:    <%= ENV.fetch('DDBJ_VALIDATOR_APP_POSTGRES_HOST', 'localhost') %>
+    pg_port:    <%= ENV.fetch('DDBJ_VALIDATOR_APP_POSTGRES_PORT', 5432) %>
+    pg_user:    <%= ENV.fetch('DDBJ_VALIDATOR_APP_POSTGRES_USER', 'validator') %>
+    pg_pass:    <%= ENV.fetch('DDBJ_VALIDATOR_APP_POSTGRES_PASSWD', 'validator') %>
     pg_timeout: 30
   monitoring:
     ssub_id: SSUB009526

--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -16,13 +16,7 @@ class AnalysisValidator < ValidatorBase
     @error_list = error_list = []
 
     @validation_config = @conf[:validation_config] # need?
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #
@@ -71,7 +65,7 @@ class AnalysisValidator < ValidatorBase
       analysis_set.each_with_index do |analysis_node, idx|
         idx += 1
         analysis_name = get_analysis_label(analysis_node, idx)
-        invalid_center_name('DRA_R0004', analysis_name, analysis_node, idx) if @use_db
+        invalid_center_name('DRA_R0004', analysis_name, analysis_node, idx)
         missing_analysis_title('DRA_R0012', analysis_name, analysis_node, idx)
         missing_analysis_description('DRA_R0014', analysis_name, analysis_node, idx)
         missing_analysis_filename('DRA_R0022', analysis_name, analysis_node, idx)

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -20,13 +20,7 @@ class BioProjectTsvValidator < ValidatorBase
     @json_schema = JSON.parse(File.read(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject/schema.json')))
     @tsv_validator = TsvFieldValidator.new()
     @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -17,13 +17,7 @@ class BioProjectValidator < ValidatorBase
 
     @validation_config = @conf[:validation_config] # need?
     @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #
@@ -73,13 +67,13 @@ class BioProjectValidator < ValidatorBase
     # submission_idは任意。Dway経由、DB登録済みデータを取得した場合にのみ取得できることを想定
     @submission_id = @xml_convertor.get_bioproject_submission_id(File.read(data_xml))
 
-    project_names_list = @db_validator.get_bioproject_names_list(@submitter_id) if @use_db
+    project_names_list = @db_validator.get_bioproject_names_list(@submitter_id)
 
     # 各プロジェクト毎の検証
     project_set.each_with_index do |project_node, idx|
       idx += 1
       project_name = get_bioporject_label(project_node, idx)
-      duplicated_project_title_and_description('BP_R0004', project_name, project_node, project_names_list, @submission_id, idx) if @use_db
+      duplicated_project_title_and_description('BP_R0004', project_name, project_node, project_names_list, @submission_id, idx)
       identical_project_title_and_description('BP_R0005', project_name, project_node, idx)
       invalid_publication_identifier('BP_R0014', project_name, project_node, idx)
 
@@ -120,7 +114,7 @@ class BioProjectValidator < ValidatorBase
     link_set = doc.xpath('//PackageSet/Package/ProjectLinks')
     # 各リンク毎の検証
     link_set.each_with_index do |link_node, idx|
-      invalid_umbrella_project('BP_R0016', 'Link', link_node, idx) if @use_db
+      invalid_umbrella_project('BP_R0016', 'Link', link_node, idx)
     end
   end
 

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -30,13 +30,7 @@ class BioSampleValidator < ValidatorBase
     @institution_list = CollDump.parse(@conf[:institution_list_file])
     @tsv_validator = TsvColumnValidator.new()
     @package_version = @conf[:biosample]['package_version']
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
     @cache = ValidatorCache.new
   end
 
@@ -232,11 +226,9 @@ class BioSampleValidator < ValidatorBase
         # 日付属性がDDBJフォーマットであるか(補正後)にチェック
         ret = invalid_datetime('BS_R0007', sample_name, attr_name.to_s, value, @conf[:ts_attr], line_num)
         non_integer_attribute_value('BS_R0093', sample_name, attr_name.to_s, value, @conf[:int_attr], line_num)
-        if @use_db
-          ret = bioproject_submission_id_replacement('BS_R0095', sample_name, biosample_data['attributes']['bioproject_id'], line_num)
-          if ret == false && !ErrorBuilder.auto_annotation(@error_list.last).nil? # save auto annotation value
-            biosample_data['attributes']['bioproject_id'] = value = ErrorBuilder.auto_annotation(@error_list.last)
-          end
+        ret = bioproject_submission_id_replacement('BS_R0095', sample_name, biosample_data['attributes']['bioproject_id'], line_num)
+        if ret == false && !ErrorBuilder.auto_annotation(@error_list.last).nil? # save auto annotation value
+          biosample_data['attributes']['bioproject_id'] = value = ErrorBuilder.auto_annotation(@error_list.last)
         end
       end
 
@@ -270,11 +262,11 @@ class BioSampleValidator < ValidatorBase
       uncultured_organism_name_for_mimag_package biosample_data
 
       ### 特定の属性値に対する検証
-      invalid_bioproject_accession('BS_R0005', sample_name, biosample_data['attributes']['bioproject_id'], line_num) if @use_db
-      bioproject_not_found('BS_R0006', sample_name, biosample_data['attributes']['bioproject_id'], @submitter_id, line_num) if @use_db
-      invalid_bioproject_type('BS_R0070', sample_name, biosample_data['attributes']['bioproject_id'], line_num) if @use_db
+      invalid_bioproject_accession('BS_R0005', sample_name, biosample_data['attributes']['bioproject_id'], line_num)
+      bioproject_not_found('BS_R0006', sample_name, biosample_data['attributes']['bioproject_id'], @submitter_id, line_num)
+      invalid_bioproject_type('BS_R0070', sample_name, biosample_data['attributes']['bioproject_id'], line_num)
       invalid_locus_tag_prefix_format('BS_R0099', sample_name, biosample_data['attributes']['locus_tag_prefix'], line_num)
-      duplicated_locus_tag_prefix('BS_R0091', sample_name, biosample_data['attributes']['locus_tag_prefix'], @biosample_list, @submission_id, line_num) if @use_db
+      duplicated_locus_tag_prefix('BS_R0091', sample_name, biosample_data['attributes']['locus_tag_prefix'], @biosample_list, @submission_id, line_num)
       ret = invalid_geo_loc_name_format('BS_R0094', sample_name, biosample_data['attributes']['geo_loc_name'], @conf[:valid_country_list], line_num)
       if ret == false && !ErrorBuilder.auto_annotation(@error_list.last).nil? # save auto annotation value
         biosample_data['attributes']['geo_loc_name'] = ErrorBuilder.auto_annotation(@error_list.last)
@@ -300,7 +292,7 @@ class BioSampleValidator < ValidatorBase
       invalid_sample_name_format('BS_R0101', sample_name, line_num)
 
       invalid_gisaid_accession('BS_R0122', sample_name, biosample_data['attributes']['gisaid_accession'], line_num)
-      biosample_not_found('BS_R0129', sample_name, biosample_data['attributes']['derived_from'], @submitter_id, line_num) if @use_db
+      biosample_not_found('BS_R0129', sample_name, biosample_data['attributes']['derived_from'], @submitter_id, line_num)
       invalid_strain_value('BS_R0135', sample_name, biosample_data['attributes']['strain'], biosample_data['attributes']['organism'], @conf[:invalid_strain_value], line_num)
 
       ### 値が複数記述される可能性がある項目の検証

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -16,13 +16,6 @@ class CombinationValidator < ValidatorBase
     @error_list = error_list = []
 
     @validation_config = @conf[:validation_config] # need?
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
   end
 
   #

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -16,13 +16,7 @@ class ExperimentValidator < ValidatorBase
     @error_list = error_list = []
 
     @validation_config = @conf[:validation_config] # need?
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #
@@ -71,7 +65,7 @@ class ExperimentValidator < ValidatorBase
       experiment_set.each_with_index do |experiment_node, idx|
         idx += 1
         experiment_name = get_experiment_label(experiment_node, idx)
-        invalid_center_name('DRA_R0004', submission_name, submission_node, acc_center_name, idx) if @use_db
+        invalid_center_name('DRA_R0004', submission_name, submission_node, acc_center_name, idx)
         missing_experiment_title('DRA_R0010', experiment_name, experiment_node, idx)
         missing_experiment_description('DRA_R0013', experiment_name, experiment_node, idx)
         missing_library_name('DRA_R0018', experiment_name, experiment_node, idx)

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -16,13 +16,7 @@ class RunValidator < ValidatorBase
     @error_list = error_list = []
 
     @validation_config = @conf[:validation_config] # need?
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #
@@ -71,7 +65,7 @@ class RunValidator < ValidatorBase
       run_set.each_with_index do |run_node, idx|
         idx += 1
         run_name = get_run_label(run_node, idx)
-        invalid_center_name('DRA_R0004', run_name, run_node, @submitter_id, idx) if @use_db
+        invalid_center_name('DRA_R0004', run_name, run_node, @submitter_id, idx)
         missing_run_title('DRA_R0011', run_name, run_node, idx)
         missing_run_filename('DRA_R0021', run_name, run_node, idx)
         invalid_run_filename('DRA_R0023', run_name, run_node, idx)

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -16,13 +16,7 @@ class SubmissionValidator < ValidatorBase
     @error_list = error_list = []
 
     @validation_config = @conf[:validation_config] # need?
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
   end
 
   #
@@ -72,7 +66,7 @@ class SubmissionValidator < ValidatorBase
       submission_set.each_with_index do |submission_node, idx|
         idx += 1
         submission_name = get_submission_label(submission_node, idx)
-        invalid_center_name('DRA_R0004', submission_name, submission_node, @submitter_id, idx) if @use_db
+        invalid_center_name('DRA_R0004', submission_name, submission_node, @submitter_id, idx)
         invalid_hold_date('DRA_R0006', submission_name, submission_node, idx)
       end
     end

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -23,13 +23,7 @@ class TradValidator < ValidatorBase
     @error_list = error_list = []
     @validation_config = @conf[:validation_config] # need?
 
-    unless @conf[:ddbj_db_config].nil?
-      @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-      @use_db = true
-    else
-      @db_validator = nil
-      @use_db = false
-    end
+    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
     @cache = ValidatorCache.new
   end
 
@@ -64,34 +58,32 @@ class TradValidator < ValidatorBase
     unnecessary_wgs_keywords('TR_R0005', annotation_list, anno_by_qual, anno_by_feat, anno_by_ent)
 
     # DBLINKチェック
-    if @use_db
-      missing_dblink('TR_R0009', data_by_feat('DBLINK', anno_by_feat), anno_by_ent)
-      invalid_bioproject_accession('TR_R0010', data_by_feat_qual('DBLINK', 'project', anno_by_qual))
-      invalid_biosample_accession('TR_R0011', data_by_feat_qual('DBLINK', 'biosample', anno_by_qual))
-      invalid_drr_accession('TR_R0012', data_by_feat_qual('DBLINK', 'sequence read archive', anno_by_qual))
-      invalid_bioproject_type('TR_R0034', data_by_feat_qual('DBLINK', 'project', anno_by_qual))
-      # biosampleの情報を取得(note.derived_from属性の参照サンプル含む)
-      biosample_id_list = data_by_feat_qual('DBLINK', 'biosample', anno_by_qual).map {|row| row[:value] }
-      biosample_info_list = get_biosample_info(biosample_id_list)
+    missing_dblink('TR_R0009', data_by_feat('DBLINK', anno_by_feat), anno_by_ent)
+    invalid_bioproject_accession('TR_R0010', data_by_feat_qual('DBLINK', 'project', anno_by_qual))
+    invalid_biosample_accession('TR_R0011', data_by_feat_qual('DBLINK', 'biosample', anno_by_qual))
+    invalid_drr_accession('TR_R0012', data_by_feat_qual('DBLINK', 'sequence read archive', anno_by_qual))
+    invalid_bioproject_type('TR_R0034', data_by_feat_qual('DBLINK', 'project', anno_by_qual))
+    # biosampleの情報を取得(note.derived_from属性の参照サンプル含む)
+    biosample_id_list = data_by_feat_qual('DBLINK', 'biosample', anno_by_qual).map {|row| row[:value] }
+    biosample_info_list = get_biosample_info(biosample_id_list)
 
-      invalid_combination_of_accessions('TR_R0013', data_by_feat('DBLINK', anno_by_feat), biosample_info_list)
+    invalid_combination_of_accessions('TR_R0013', data_by_feat('DBLINK', anno_by_feat), biosample_info_list)
 
-      unless submitter_id.nil? || submitter_id.chomp.strip == ''
-        inconsistent_submitter('TR_R0014', data_by_feat('DBLINK', anno_by_feat), submitter_id)
-      end
-
-      # BioSample整合性チェック
-      all_entry_name_list = anno_by_ent.keys
-      biosample_line = data_by_feat_qual('DBLINK', 'biosample', anno_by_qual)
-      inconsistent_organism_with_biosample('TR_R0015', data_by_qual('organism', anno_by_qual), data_by_qual('strain', anno_by_qual), biosample_line, biosample_info_list)
-      inconsistent_isolate_with_biosample('TR_R0016', data_by_qual('isolate', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
-      inconsistent_isolation_source_with_biosample('TR_R0017', data_by_qual('isolation_source', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
-      inconsistent_collection_date_with_biosample('TR_R0018', data_by_qual('collection_date', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
-      inconsistent_country_with_biosample('TR_R0019', data_by_feat_qual('source', 'country', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
-      inconsistent_locus_tag_with_biosample('TR_R0020', data_by_qual('locus_tag', anno_by_qual), biosample_line, biosample_info_list)
-      inconsistent_culture_collection_with_biosample('TR_R0030', data_by_qual('culture_collection', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
-      inconsistent_host_with_biosample('TR_R0031', data_by_qual('host', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    unless submitter_id.nil? || submitter_id.chomp.strip == ''
+      inconsistent_submitter('TR_R0014', data_by_feat('DBLINK', anno_by_feat), submitter_id)
     end
+
+    # BioSample整合性チェック
+    all_entry_name_list = anno_by_ent.keys
+    biosample_line = data_by_feat_qual('DBLINK', 'biosample', anno_by_qual)
+    inconsistent_organism_with_biosample('TR_R0015', data_by_qual('organism', anno_by_qual), data_by_qual('strain', anno_by_qual), biosample_line, biosample_info_list)
+    inconsistent_isolate_with_biosample('TR_R0016', data_by_qual('isolate', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    inconsistent_isolation_source_with_biosample('TR_R0017', data_by_qual('isolation_source', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    inconsistent_collection_date_with_biosample('TR_R0018', data_by_qual('collection_date', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    inconsistent_country_with_biosample('TR_R0019', data_by_feat_qual('source', 'country', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    inconsistent_locus_tag_with_biosample('TR_R0020', data_by_qual('locus_tag', anno_by_qual), biosample_line, biosample_info_list)
+    inconsistent_culture_collection_with_biosample('TR_R0030', data_by_qual('culture_collection', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
+    inconsistent_host_with_biosample('TR_R0031', data_by_qual('host', anno_by_qual), all_entry_name_list, biosample_line, biosample_info_list)
     other_insdc_partners_accession('TR_R0033', data_by_feat('DBLINK', anno_by_feat))
 
     # locus_tagチェック
@@ -622,12 +614,10 @@ class TradValidator < ValidatorBase
     bioproject_list.each do |bioproject_line|
       bioproject_accession = bioproject_line[:value]
       if bioproject_accession =~ /^PRJD\w?\d{1,}$/
-        unless @db_validator.nil?
-          unless @db_validator.valid_bioproject_id?(bioproject_accession)
-            result = false
-            invalid_id_list.push(bioproject_accession)
-            line_no_list.push(bioproject_line[:line_no].to_s)
-          end
+        unless @db_validator.valid_bioproject_id?(bioproject_accession)
+          result = false
+          invalid_id_list.push(bioproject_accession)
+          line_no_list.push(bioproject_line[:line_no].to_s)
         end
       elsif bioproject_accession =~ /^PRJ(E|N)\w?\d{1,}$/
         # 他極データは無視(TR_R0033でチェックする)
@@ -668,12 +658,10 @@ class TradValidator < ValidatorBase
     biosample_list.each do |biosample_line|
       biosample_accession = biosample_line[:value]
       if biosample_accession =~ /^SAMD\w?\d{1,}$/
-        unless @db_validator.nil?
-          unless @db_validator.is_valid_biosample_id?(biosample_accession)
-            result = false
-            invalid_id_list.push(biosample_accession)
-            line_no_list.push(biosample_line[:line_no].to_s)
-          end
+        unless @db_validator.is_valid_biosample_id?(biosample_accession)
+          result = false
+          invalid_id_list.push(biosample_accession)
+          line_no_list.push(biosample_line[:line_no].to_s)
         end
       elsif biosample_accession =~ /^SAM(E|N)\w?\d{1,}$/
         # 他極データは無視(TR_R0033でチェックする)
@@ -714,9 +702,7 @@ class TradValidator < ValidatorBase
     # DRRは複数記載されるケースがあり、まとめてDBチェックする
     drr_accession_id_list = drr_list.map {|row| row[:value] }
     drr_accession_id_list.delete_if {|run_id| run_id =~ /^(S|E)RR\w?\d{1,}$/ } # 他極データは無視(TR_R0033でチェックする)
-    unless @db_validator.nil?
-      result_run_list = @db_validator.exist_check_run_ids(drr_accession_id_list)
-    end
+    result_run_list = @db_validator.exist_check_run_ids(drr_accession_id_list)
     result_run_list.each do |result_run_id|
       if result_run_id[:is_exist] == false
         invalid_id_list.push(result_run_id[:accession_id])
@@ -785,24 +771,22 @@ class TradValidator < ValidatorBase
   def get_biosample_info(biosample_id_list)
     return {} if biosample_id_list.nil? || biosample_id_list.empty?
 
-    unless @db_validator.nil?
-      ref_biosample_id_list = []
-      biosample_info = @db_validator.get_biosample_metadata(biosample_id_list)
-      biosample_info.each do |biosample_id, biosample_data|
-        biosample_data[:attribute_list].each do |attr|
-          if attr[:attribute_name] == 'note' || attr[:attribute_name] == 'derived_from'
-            ref_list = attr[:attribute_value].scan(/SAMD\w?\d{1,}/)
-            biosample_data[:ref_biosample_list] = [] if biosample_data[:ref_biosample_list].nil?
-            biosample_data[:ref_biosample_list].concat(ref_list).uniq!
-            ref_biosample_id_list.concat(ref_list)
-          end
+    ref_biosample_id_list = []
+    biosample_info = @db_validator.get_biosample_metadata(biosample_id_list)
+    biosample_info.each do |biosample_id, biosample_data|
+      biosample_data[:attribute_list].each do |attr|
+        if attr[:attribute_name] == 'note' || attr[:attribute_name] == 'derived_from'
+          ref_list = attr[:attribute_value].scan(/SAMD\w?\d{1,}/)
+          biosample_data[:ref_biosample_list] = [] if biosample_data[:ref_biosample_list].nil?
+          biosample_data[:ref_biosample_list].concat(ref_list).uniq!
+          ref_biosample_id_list.concat(ref_list)
         end
       end
-      # noteかderived_fromに記載された
-      if ref_biosample_id_list.any?
-        ref_biosample_info = @db_validator.get_biosample_metadata(ref_biosample_id_list.uniq)
-        biosample_info.merge!(ref_biosample_info)
-      end
+    end
+    # noteかderived_fromに記載された
+    if ref_biosample_id_list.any?
+      ref_biosample_info = @db_validator.get_biosample_metadata(ref_biosample_id_list.uniq)
+      biosample_info.merge!(ref_biosample_info)
     end
     biosample_info
   end
@@ -1008,7 +992,6 @@ class TradValidator < ValidatorBase
   def invalid_combination_of_accessions(rule_code, dblink_list, biosample_info)
     return nil if dblink_list.nil? || dblink_list.empty?
     return nil if biosample_info.nil? || biosample_info == {}
-    return nil if @db_validator.nil?
     ret = true
 
     # 他極データは無視
@@ -1120,7 +1103,6 @@ class TradValidator < ValidatorBase
   def inconsistent_submitter(rule_code, dblink_list, submitter_id)
     return nil if dblink_list.nil? || dblink_list.empty?
     return nil if submitter_id.nil? || submitter_id == ''
-    return nil if @db_validator.nil?
     ret = true
 
     # 他極データは無視
@@ -1675,7 +1657,6 @@ class TradValidator < ValidatorBase
   #
   def invalid_bioproject_type(rule_code, bioproject_list)
     return nil if bioproject_list.nil? || bioproject_list.empty?
-    return nil if @db_validator.nil?
 
     ret  = true
     bioproject_list.each do |row|

--- a/lib/validator/validator_base.rb
+++ b/lib/validator/validator_base.rb
@@ -11,12 +11,9 @@ class ValidatorBase
   def read_common_config
     setting = Rails.configuration.validator
 
-    db = setting['ddbj_rdb']
-    db_configured = db && %w[pg_host pg_port pg_user pg_pass].all? { db[it].to_s != '' }
-
     {
       sparql_config:   setting['sparql_endpoint'],
-      ddbj_db_config:  db_configured ? db : nil,
+      ddbj_db_config:  setting['ddbj_rdb'],
       named_graph_uri: setting['named_graph_uri'],
       biosample:       setting['biosample'],
       log_dir:         setting.dig('api_log', 'path')

--- a/test/lib/validator/biosample_validator_test.rb
+++ b/test/lib/validator/biosample_validator_test.rb
@@ -10,13 +10,8 @@ class TestBioSampleValidator < Minitest::Test
     @validator = BioSampleValidator.new
     @xml_convertor = XmlConvertor.new
     @test_file_dir = File.expand_path('../../../data/biosample', __FILE__)
-    # DDBJ RDBを使用するテストするか否か。を Rails 設定から判定
-    setting = Rails.configuration.validator
-    @ddbj_db_mode = true
-    if setting['ddbj_rdb'].nil? || setting['ddbj_rdb']['pg_host'].nil? || setting['ddbj_rdb']['pg_host'] == ''
-      @ddbj_db_mode = false
-    end
-    @package_version = setting['biosample']['package_version']
+    @ddbj_db_mode = ServiceAvailability::PG_CONFIGURED
+    @package_version = Rails.configuration.validator['biosample']['package_version']
   end
 
   #### テスト用共通メソッド ####

--- a/test/lib/validator/trad_validator_test.rb
+++ b/test/lib/validator/trad_validator_test.rb
@@ -9,12 +9,7 @@ class TestTradValidator < Minitest::Test
     skip_unless_virtuoso_available
     @validator = TradValidator.new
     @test_file_dir = File.expand_path('../../../data/trad', __FILE__)
-    # DDBJ RDBを使用するテストするか否か。を Rails 設定から判定
-    setting = Rails.configuration.validator
-    @ddbj_db_mode = true
-    if setting['ddbj_rdb'].nil? || setting['ddbj_rdb']['pg_host'].nil? || setting['ddbj_rdb']['pg_host'] == ''
-      @ddbj_db_mode = false
-    end
+    @ddbj_db_mode = ServiceAvailability::PG_CONFIGURED
   end
 
   #### テスト用共通メソッド ####

--- a/test/lib/validator/validator_test.rb
+++ b/test/lib/validator/validator_test.rb
@@ -5,6 +5,7 @@ require 'validator/validator'
 class TestValidator < Minitest::Test
   def setup
     skip_unless_virtuoso_available
+    skip_unless_pg_configured
     @validator = Validator.new
     @tmp_file_dir = File.expand_path('../../../data/tmp', __FILE__)
     @bs_test_file_dir = File.expand_path('../../../data/biosample', __FILE__)


### PR DESCRIPTION
## Summary

カテゴリ B 改: 「設定がなければスキップ」アンチパターンを全環境で統一的に廃止。

PR #185 では `Rails.env.local?` で起動時 fail-fast を staging/production だけに限定していたが、env 分岐が残るとどの環境でどれが必須か読みにくい。**全環境で必須** にして、dev/test は YAML 側に **ENV.fetch のデフォルト** を仕込んで boot 検査を必ず通す形に統一した。

### YAML / 起動時 fail-fast

- `config/validator.yml` の development セクションで `pg_host`/`pg_port`/`pg_user`/`pg_pass` を `ENV.fetch(name, default)` 形式に。デフォルトは `localhost` / `5432` / `validator` / `validator`
- `config/initializers/validator_config.rb` (新規) は env 分岐なしに `db.has_key?(:pg_host)` 等で全 4 鍵が populate されているか検査、欠けていれば `RuntimeError` で boot 失敗

### in-process プラミングの撤去

- `validator_base#read_common_config` から `db_configured` ショートカットを削除、`setting['ddbj_rdb']` をそのまま渡す
- 9 つの validator の initialize から `unless @conf[:ddbj_db_config].nil?` 分岐を撤去、`@db_validator` は常に作られる (`@use_db` フラグも消滅)
- `trad_validator.rb` の call-site `unless @db_validator.nil?` ブロック (4 箇所) と `return nil if @db_validator.nil?` 早期 return (3 箇所) を撤去
- `analysis` / `bioproject` / `biosample` / `experiment` / `run` / `submission` の suffix `if @use_db` ガードと `biosample_validator` の block-form `if @use_db` を撤去
- `combination_validator.rb` は `@db_validator` を一度も使っていない死コードだったので init 行ごと削除

### test 側

- `TestValidator` は full pipeline 経由で BioSampleValidator を叩くので `skip_unless_pg_configured` を setup に追加
- `biosample_validator_test` / `trad_validator_test` の `@ddbj_db_mode` 検出を `ServiceAvailability::PG_CONFIGURED` (= `ENV.key?('DDBJ_VALIDATOR_APP_POSTGRES_HOST')`) ベースに変更。デフォルト populate 後も「operator が PG を意図的に設定したか」を判定基準にする (CI で skip される対象は維持)

## Test plan

- [x] `bin/rails zeitwerk:check` → All is good!
- [x] `bin/rails test` → 328 runs / 2169 assertions / 0 failures / 0 errors / 39 skips (skip 数は ENV 未設定環境で +3、PG が動いていれば +0)
- [x] `RAILS_ENV=production rails runner '...'` で boot 成功 (production credentials の postgres.password 設定済み)
- [ ] staging デプロイ後、validation/submission の golden path 確認

## 残タスク

- production の `postgres.password = "const"` ローテート (DB 側作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)