### PR TITLE
Make validators thread-safe; bring Puma/Dockerfile closer to Rails 8 defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,44 @@
-FROM ruby:4.0.3
+# syntax=docker/dockerfile:1
+# check=error=true
 
-ENV RAILS_ENV=production \
-    BUNDLE_WITHOUT=development:test
+# 本番向け Dockerfile。compose.yaml が host のソースを WORKDIR に bind mount するので、
+# 最終 image にコードを焼き付けない (ビルド時のキャッシュ用に COPY はしている)。
+# Rails 8 の scaffold Dockerfile に倣い multi-stage / slim base / jemalloc を採用。
 
-WORKDIR /usr/src/ddbj_validator/
+ARG RUBY_VERSION=4.0.3
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
-COPY ./Gemfile ./Gemfile.lock ./
-RUN bundle install
+WORKDIR /usr/src/ddbj_validator
 
-COPY ./ ./
+# Install base packages (libpq for pg gem, libjemalloc2 for memory allocator)
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libpq-dev libxslt1.1 libyaml-0-2 && \
+    ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development:test" \
+    LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential git libxslt-dev libyaml-dev pkg-config && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile -j 1 --gemfile
+
+# Final stage for app image
+FROM base
+
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 
 EXPOSE 3000
-CMD ["bundle", "exec", "puma", "-C", "/usr/src/ddbj_validator/config/puma.rb"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -6,7 +6,7 @@ class MonitoringController < ApplicationController
   # NG のときは HTTP 503 で返すことで curl --fail probe を失敗させる。
   def show
     submission_id = validator_setting.dig('monitoring', 'ssub_id') || 'SSUB009526'
-    api_url       = "http://localhost:#{ENV.fetch('DDBJ_VALIDATOR_APP_UNICORN_PORT', '3000')}/api/"
+    api_url       = "http://localhost:#{ENV.fetch('PORT', '3000')}/api/"
 
     xml_body = HTTP.headers('API_KEY' => 'curator').get("#{api_url}submission/biosample/#{submission_id}").body.to_s
     raise "Can't get submission xml file. Please check the validation service." unless xml_body.start_with?('<?xml')

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       RUBY_YJIT_ENABLE: "true"
       RAILS_ENV: ${RAILS_ENV}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
-      DDBJ_VALIDATOR_APP_UNICORN_PORT: 3000
+      WEB_CONCURRENCY: 4
     user: 0:0
     volumes:
       - ${PWD}:/usr/src/ddbj_validator

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,13 +1,12 @@
-# Puma configuration.
-#
-# 4 workers / 1 thread each で unicorn 時代の設定を踏襲している。コードベースはまだ
-# thread safety を監査していないので多 thread 化は別タスク扱い。
-# preload_app! で worker 間は copy-on-write で memory を共有する。
+# Rails 8 scaffold default + preload_app! (workers 間で copy-on-write メモリ共有)。
+# threads は WEB_CONCURRENCY × RAILS_MAX_THREADS の組合せでチューニングする。
+threads_count = Integer(ENV.fetch('RAILS_MAX_THREADS', 3))
+threads threads_count, threads_count
 
-port     Integer(ENV.fetch('DDBJ_VALIDATOR_APP_UNICORN_PORT', '3000'))
-workers  Integer(ENV.fetch('DDBJ_VALIDATOR_APP_PUMA_WORKERS', '4'))
-threads  1, 1
+port Integer(ENV.fetch('PORT', 3000))
 
 preload_app!
 
 plugin :tmp_restart
+
+pidfile ENV['PIDFILE'] if ENV['PIDFILE']

--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -10,8 +10,7 @@ class AnalysisValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -10,7 +10,6 @@ class AnalysisValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -10,8 +10,6 @@ class BioProjectTsvValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
-    @conf[:null_accepted] = @conf[:field_settings]['null_value']['value_list']
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 
@@ -278,7 +276,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
 
     unless sample_scope.downcase == 'multiisolate' # multiの場合は無視
-      if organism_name.blank? || @nullability.null_value?(organism_name) # organismの記載がない
+      if organism_name.blank? || InsdcNullability.null_value?(organism_name) # organismの記載がない
         result = false
         annotation = [
           {key: 'organism', value: ''},

--- a/lib/validator/bioproject_tsv_validator.rb
+++ b/lib/validator/bioproject_tsv_validator.rb
@@ -11,8 +11,7 @@ class BioProjectTsvValidator < ValidatorBase
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
     @conf[:null_accepted] = @conf[:field_settings]['null_value']['value_list']
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 
@@ -279,7 +278,7 @@ class BioProjectTsvValidator < ValidatorBase
     result = true
 
     unless sample_scope.downcase == 'multiisolate' # multiの場合は無視
-      if organism_name.blank? || InsdcNullability.null_value?(organism_name) # organismの記載がない
+      if organism_name.blank? || @nullability.null_value?(organism_name) # organismの記載がない
         result = false
         annotation = [
           {key: 'organism', value: ''},

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -10,7 +10,6 @@ class BioProjectValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -10,8 +10,7 @@ class BioProjectValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -18,7 +18,6 @@ class BioSampleValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/biosample')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
     @date_format = DateFormat.new(@conf)
 
     @error_list = error_list = []
@@ -233,13 +232,13 @@ class BioSampleValidator < ValidatorBase
 
       ### organismの検証とtaxonomy_idの確定
       input_taxid = biosample_data['attributes']['taxonomy_id']
-      if input_taxid.nil? || @nullability.null_value?(input_taxid) # taxonomy_idの記述がない("missing"も未記入とみなす)
+      if input_taxid.nil? || InsdcNullability.null_value?(input_taxid) # taxonomy_idの記述がない("missing"も未記入とみなす)
         taxonomy_id = OrganismValidator::TAX_INVALID # tax_idを使用するルールをスキップさせるために無効値をセット
       else
         taxonomy_id = input_taxid
       end
       input_organism = biosample_data['attributes']['organism']
-      if !(input_organism.nil? && @nullability.null_value?(input_organism)) # organismの記述がある("missing"は未記入とみなす)
+      if !(input_organism.nil? && InsdcNullability.null_value?(input_organism)) # organismの記述がある("missing"は未記入とみなす)
         if taxonomy_id != OrganismValidator::TAX_INVALID # tax_idの記述がある
           ret = taxonomy_name_and_id_not_match('BS_R0004', sample_name, taxonomy_id, input_organism, line_num)
         else
@@ -741,7 +740,7 @@ class BioSampleValidator < ValidatorBase
   #
   def missing_sample_name (rule_code, sample_name, biosample_data, line_num)
     return nil if biosample_data.nil? || biosample_data['attributes'].nil?
-    return true unless @nullability.null_value?(biosample_data['attributes']['sample_name'])
+    return true unless InsdcNullability.null_value?(biosample_data['attributes']['sample_name'])
 
     annotation = [
       {key: 'Sample name', value: biosample_data['attributes']['sample_name'].to_s},
@@ -763,7 +762,7 @@ class BioSampleValidator < ValidatorBase
   #
   def missing_organism (rule_code, sample_name, biosample_data, line_num)
     return nil if biosample_data.nil? || biosample_data['attributes'].nil?
-    return true unless @nullability.null_value?(biosample_data['attributes']['organism'])
+    return true unless InsdcNullability.null_value?(biosample_data['attributes']['organism'])
 
     annotation = [
       {key: 'Sample name', value: sample_name},
@@ -927,7 +926,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def attribute_value_not_in_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
 
     result =  true
     if !cv_attr[attr_name].nil? # CVを使用する属性か
@@ -982,7 +981,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_attribute_value_for_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
 
     # CVを使用しない属性か、CVリストに値があれば OK
     return true if cv_attr[attr_name].nil? || cv_attr[attr_name].include?(attr_val)
@@ -1010,7 +1009,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_publication_identifier (rule_code, sample_name, attr_name, attr_val, ref_attr, line_num)
-    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
 
     result =  true
     if ref_attr.include?(attr_name) # リファレンス型の属性か
@@ -1087,7 +1086,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_accession (rule_code, sample_name, bioproject_accession, line_num)
-    return nil if @nullability.null_value?(bioproject_accession)
+    return nil if InsdcNullability.null_value?(bioproject_accession)
 
     result = true
     if bioproject_accession =~ /^PRJ[D|E|N]\w?\d{1,}$/ || bioproject_accession =~ /^PSUB\d{6}$/
@@ -1125,7 +1124,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_geo_loc_name_format (rule_code, sample_name, geo_loc_name, country_list, line_num)
-    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_not_recommended_value?(geo_loc_name)
+    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_not_recommended_value?(geo_loc_name)
 
     annotated_name = geo_loc_name.sub(/\s*:\s*/, ':') # 最初のコロンの前後の空白を詰める
     # 2つ目以降の":"は", "に置換する
@@ -1185,7 +1184,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_country (rule_code, sample_name, geo_loc_name, country_list, line_num)
-    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_not_recommended_value?(geo_loc_name)
+    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_not_recommended_value?(geo_loc_name)
     country_name = geo_loc_name.split(':').first.strip
     matched_country = country_list.select {|country| country == country_name }
     if matched_country.any?
@@ -1213,7 +1212,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_lat_lon_format (rule_code, sample_name, lat_lon, line_num)
-    return nil if @nullability.null_value?(lat_lon)
+    return nil if InsdcNullability.null_value?(lat_lon)
 
     insdc_latlon = Geolocation.format_insdc_latlon(lat_lon)
     # INSDC の formatに直せなかった場合はnilが返るが、auto-correctはないのでこのメソッドでは無視。これらはBS_R0139でエラーになる。
@@ -1244,7 +1243,7 @@ class BioSampleValidator < ValidatorBase
   # 実際に別の国にいる時だけ warning を返す
   #
   def latlon_versus_country (rule_code, sample_name, geo_loc_name, lat_lon, line_num)
-    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_value?(lat_lon)
+    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_value?(lat_lon)
 
     country_name = geo_loc_name.split(':').first.strip
     expected_iso = Geolocation.insdc_to_iso_a3[country_name]
@@ -1289,7 +1288,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_lat_lon (rule_code, sample_name, lat_lon, line_num)
-    return nil if @nullability.null_value?(lat_lon)
+    return nil if InsdcNullability.null_value?(lat_lon)
 
     result = true
     insdc_latlon = Geolocation.format_insdc_latlon(lat_lon)
@@ -1323,7 +1322,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_host_organism_name (rule_code, sample_name, host_taxid, host_name, line_num)
-    return nil if @nullability.null_value?(host_name)
+    return nil if InsdcNullability.null_value?(host_name)
     ret = true
 
     annotation = [
@@ -1413,7 +1412,7 @@ class BioSampleValidator < ValidatorBase
   # taxonomy_idの指定が無かった場合に実行されるため、常にfalseを返す
   #
   def taxonomy_error_warning (rule_code, sample_name, organism_name, line_num)
-    return nil if @nullability.null_value?(organism_name)
+    return nil if InsdcNullability.null_value?(organism_name)
     # あればキャッシュを使用
     if @cache.check(ValidatorCache::EXIST_ORGANISM_NAME, organism_name).nil?
       ret = @org_validator.suggest_taxid_from_name(organism_name)
@@ -1478,7 +1477,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def taxonomy_name_and_id_not_match (rule_code, sample_name, taxonomy_id, organism_name, line_num)
-    return nil if @nullability.null_value?(organism_name) || @nullability.null_value?(taxonomy_id)
+    return nil if InsdcNullability.null_value?(organism_name) || InsdcNullability.null_value?(taxonomy_id)
 
     # あればキャッシュを使用
     if @cache.has_key(ValidatorCache::TAX_MATCH_ORGANISM, taxonomy_id) == false # cache値がnilの可能性があるためhas_keyでチェック
@@ -1519,7 +1518,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def package_versus_organism (rule_code, sample_name, taxonomy_id, package_name, organism, line_num)
-    return nil if package_name.blank? || @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if package_name.blank? || InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
 
     # あればキャッシュを使用
     cache_key = ValidatorCache.create_key(taxonomy_id, package_name)
@@ -1562,7 +1561,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def sex_for_bacteria (rule_code, sample_name, taxonomy_id, sex, organism, line_num)
-    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID || @nullability.null_value?(sex)
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID || InsdcNullability.null_value?(sex)
 
     ret = true
     bac_vir_linages = [OrganismValidator::TAX_BACTERIA, OrganismValidator::TAX_VIRUSES]
@@ -1624,13 +1623,13 @@ class BioSampleValidator < ValidatorBase
     vouchers_list = []
     attr_list.each do |attr|
       unless attr['culture_collection'].nil?
-        vouchers_list.push({attr_name: 'culture_collection', attr_no: attr['attr_no'], value: attr['culture_collection'], institution_code: attr['culture_collection'].split(':').first.strip}) unless @nullability.null_value?(attr['culture_collection'])
+        vouchers_list.push({attr_name: 'culture_collection', attr_no: attr['attr_no'], value: attr['culture_collection'], institution_code: attr['culture_collection'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['culture_collection'])
       end
       unless attr['specimen_voucher'].nil?
-        vouchers_list.push({attr_name: 'specimen_voucher', attr_no: attr['attr_no'], value: attr['specimen_voucher'], institution_code: attr['specimen_voucher'].split(':').first.strip}) unless @nullability.null_value?(attr['specimen_voucher'])
+        vouchers_list.push({attr_name: 'specimen_voucher', attr_no: attr['attr_no'], value: attr['specimen_voucher'], institution_code: attr['specimen_voucher'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['specimen_voucher'])
       end
       unless attr['bio_material'].nil?
-        vouchers_list.push({attr_name: 'bio_material', attr_no: attr['attr_no'], value: attr['bio_material'], institution_code: attr['bio_material'].split(':').first.strip}) unless @nullability.null_value?(attr['bio_material'])
+        vouchers_list.push({attr_name: 'bio_material', attr_no: attr['attr_no'], value: attr['bio_material'], institution_code: attr['bio_material'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['bio_material'])
       end
     end
 
@@ -1688,7 +1687,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def future_collection_date (rule_code, sample_name, collection_date, line_num)
-    return nil if @nullability.null_value?(collection_date) || @nullability.null_not_recommended_value?(collection_date)
+    return nil if InsdcNullability.null_value?(collection_date) || InsdcNullability.null_not_recommended_value?(collection_date)
     result = nil
     # DDBJ 日付型へのフォーマットを試みる
     collection_date = @date_format.format_date2ddbj(collection_date)
@@ -1824,10 +1823,10 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime_format (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num)
-    return nil if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) # 日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
-    return nil if attr_name == 'collection_date' && (@nullability.null_not_recommended_value?(attr_val))
+    return nil if attr_name == 'collection_date' && (InsdcNullability.null_not_recommended_value?(attr_val))
 
     attr_val_org = attr_val
     result = true
@@ -1879,10 +1878,10 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num)
-    return nil if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) # 日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
-    return nil if attr_name == 'collection_date' && (@nullability.null_not_recommended_value?(attr_val))
+    return nil if attr_name == 'collection_date' && (InsdcNullability.null_not_recommended_value?(attr_val))
 
     result = true
     is_ddbj_format = @date_format.ddbj_date_format?(attr_val) # DDBJフォーマットであるか
@@ -1918,7 +1917,7 @@ class BioSampleValidator < ValidatorBase
       return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == 'attr_value' # 属性値の検証
-      return nil if attr_name.blank? || @nullability.null_value?(attr_val)
+      return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -1979,12 +1978,12 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def redundant_taxonomy_attributes (rule_code, sample_name, organism, host, isolation_source, line_num)
-    return nil  if @nullability.null_value?(organism) && @nullability.null_value?(host) && @nullability.null_value?(isolation_source)
+    return nil  if InsdcNullability.null_value?(organism) && InsdcNullability.null_value?(host) && InsdcNullability.null_value?(isolation_source)
 
     taxon_values = []
-    taxon_values.push(organism) unless @nullability.null_value?(organism)
-    taxon_values.push(host) unless @nullability.null_value?(host)
-    taxon_values.push(isolation_source) unless @nullability.null_value?(isolation_source)
+    taxon_values.push(organism) unless InsdcNullability.null_value?(organism)
+    taxon_values.push(host) unless InsdcNullability.null_value?(host)
+    taxon_values.push(isolation_source) unless InsdcNullability.null_value?(isolation_source)
     uniq_taxon_values = taxon_values.map {|tax_name|
       tax_name.strip.gsub(' ', '').downcase
     }.uniq
@@ -2024,7 +2023,7 @@ class BioSampleValidator < ValidatorBase
       return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == 'attr_value' # 属性値の検証
-      return nil if attr_name.blank? || @nullability.null_value?(attr_val)
+      return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -2081,7 +2080,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_ascii_attribute_value (rule_code, sample_name, attr_name, attr_val, line_num)
-    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
     return true if attr_val.ascii_only?
 
     # 属性値のどこにnon ascii文字があるか示すメッセージを作成
@@ -2150,7 +2149,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def bioproject_not_found (rule_code, sample_name, bioproject_accession, submitter_id, line_num)
-    return nil if @nullability.null_value?(bioproject_accession)
+    return nil if InsdcNullability.null_value?(bioproject_accession)
     return nil if submitter_id.nil?
 
     # cache 値が nil の可能性があるため has_key で判定する
@@ -2247,7 +2246,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_type (rule_code, sample_name, bioproject_accession, line_num)
-    return nil if @nullability.null_value?(bioproject_accession)
+    return nil if InsdcNullability.null_value?(bioproject_accession)
 
     if @cache.check(ValidatorCache::IS_UMBRELLA_ID, bioproject_accession).nil?
       is_umbrella = @db_validator.umbrella_project?(bioproject_accession)
@@ -2279,7 +2278,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_integer_attribute_value (rule_code, sample_name, attr_name, attr_val, int_attr, line_num)
-    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
     # 整数型の属性であり有効な入力値がある場合だけチェック
     return true unless int_attr.include?(attr_name)
 
@@ -2402,7 +2401,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def duplicated_locus_tag_prefix (rule_code, sample_name, locus_tag, biosample_list, submission_id, line_num)
-    return nil if @nullability.null_value?(locus_tag)
+    return nil if InsdcNullability.null_value?(locus_tag)
     result = true
 
     # 同一ファイル内での重複チェック
@@ -2451,7 +2450,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def bioproject_submission_id_replacement (rule_code, sample_name, psub_id, line_num)
-    return nil if @nullability.null_value?(psub_id)
+    return nil if InsdcNullability.null_value?(psub_id)
     result = true
 
     if /^PSUB/ =~ psub_id
@@ -2497,7 +2496,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, sample_name, taxonomy_id, organism, line_num)
-    return nil if @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
     result = @org_validator.is_infraspecific_rank(taxonomy_id)
     if result == false
       annotation = [
@@ -2564,7 +2563,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_locus_tag_prefix_format (rule_code, sample_name, locus_tag, line_num)
-    return nil  if @nullability.null_value?(locus_tag)
+    return nil  if InsdcNullability.null_value?(locus_tag)
     return true if locus_tag.size.between?(3, 12) && locus_tag =~ /^[0-9a-zA-Z]+$/ && locus_tag !~ /^[0-9]+/
 
     annotation = [
@@ -2633,7 +2632,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_sample_name_format (rule_code, sample_name, line_num)
-    return nil  if @nullability.null_value?(sample_name)
+    return nil  if InsdcNullability.null_value?(sample_name)
     return true if sample_name.size <= 100 && sample_name =~ /^[0-9a-zA-Z\s\(\)\{\}\[\]\+\-_.]+$/  # 最大100文字で英数字、空白、記号 (){}[]+-_. から構成されること
 
     annotation = [
@@ -2659,12 +2658,12 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_taxonomy_for_genome_sample (rule_code, sample_name, package_name, taxonomy_id, organism, line_num)
-    return nil if package_name.blank? || @nullability.null_value?(organism)
+    return nil if package_name.blank? || InsdcNullability.null_value?(organism)
     result = true
     if package_name.start_with?('MIGS.ba') || package_name.start_with?('MIGS.eu')
       # "sp."終わり、または"xxx sp. (in: yyy)", "xxx sp. (ex yyy)"であればエラー seealso: https://ddbj-dev.atlassian.net/browse/VALIDATOR-14
       if organism.downcase.end_with?('sp.') || organism =~ /.+sp\.\s*\((in\:|ex)\s.*\)$/
-        if @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+        if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
           # tax_idが不明な場合、新規生物種登録の可能性がありstrain名をつけてもらいたいためエラー
           result = false
         else
@@ -2697,7 +2696,7 @@ class BioSampleValidator < ValidatorBase
   # ==== Return
   # true/false
   def taxonomy_warning (rule_code, sample_name, component_organism, attr_no, line_num)
-    return nil if @nullability.null_value?(component_organism)
+    return nil if InsdcNullability.null_value?(component_organism)
     ret = true
 
     annotation = [
@@ -2751,7 +2750,7 @@ class BioSampleValidator < ValidatorBase
   # ==== Return
   # true/false
   def invalid_metagenome_source (rule_code, sample_name, metagenome_source, attr_idx, line_num)
-    return nil if @nullability.null_value?(metagenome_source)
+    return nil if InsdcNullability.null_value?(metagenome_source)
     ret = true
 
     metagenome_linages = [OrganismValidator::TAX_METAGENOMES]
@@ -2816,7 +2815,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_culture_collection_format (rule_code, sample_name, culture_collection, line_num)
-    return nil if @nullability.null_value?(culture_collection)
+    return nil if InsdcNullability.null_value?(culture_collection)
 
     ret = true
     if culture_collection.split(':').size < 2 || culture_collection.split(':').size > 3
@@ -2845,7 +2844,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_culture_collection (rule_code, sample_name, culture_collection, institution_list, attr_idx, line_num)
-    return nil if @nullability.null_value?(culture_collection) || institution_list.nil?
+    return nil if InsdcNullability.null_value?(culture_collection) || institution_list.nil?
     return nil if culture_collection.split(':').size < 2 || culture_collection.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'culture_collection', culture_collection, institution_list, attr_idx, line_num)
@@ -2865,7 +2864,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def specimen_voucher_for_bacteria_and_unclassified_sequences (rule_code, sample_name, specimen_voucher, taxonomy_id, line_num)
-    return nil if @nullability.null_value?(specimen_voucher) ||  @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if InsdcNullability.null_value?(specimen_voucher) ||  InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
 
     ret = @org_validator.target_organism_for_specimen_voucher?(taxonomy_id)
     if ret == false
@@ -2892,7 +2891,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_specimen_voucher_format (rule_code, sample_name, specimen_voucher, line_num)
-    return nil if @nullability.null_value?(specimen_voucher)
+    return nil if InsdcNullability.null_value?(specimen_voucher)
 
     ret = true
     if specimen_voucher.split(':').size > 3 # <institution-code>と<collection-code>共に省略可能なので、区切り文字(":")が多くないかだけチェック
@@ -2921,7 +2920,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_specimen_voucher (rule_code, sample_name, specimen_voucher, institution_list, attr_idx, line_num)
-    return nil if @nullability.null_value?(specimen_voucher) || institution_list.nil?
+    return nil if InsdcNullability.null_value?(specimen_voucher) || institution_list.nil?
     return nil if specimen_voucher.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'specimen_voucher', specimen_voucher, institution_list, attr_idx, line_num)
@@ -2940,7 +2939,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bio_material_format (rule_code, sample_name, bio_material, line_num)
-    return nil if @nullability.null_value?(bio_material)
+    return nil if InsdcNullability.null_value?(bio_material)
 
     ret = true
     if bio_material.split(':').size > 3 # <institution-code>と<collection-code>共に省略可能なので、区切り文字(":")が多くないかだけチェック
@@ -2968,7 +2967,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bio_material (rule_code, sample_name, bio_material, institution_list, line_num)
-    return nil if @nullability.null_value?(bio_material) || institution_list.nil?
+    return nil if InsdcNullability.null_value?(bio_material) || institution_list.nil?
     return nil if bio_material.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'bio_material', bio_material, institution_list, nil, line_num)
@@ -3095,7 +3094,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_gisaid_accession (rule_code, sample_name, gisaid_accession, line_num)
-    return nil  if @nullability.null_value?(gisaid_accession)
+    return nil  if InsdcNullability.null_value?(gisaid_accession)
     return true if gisaid_accession =~ /^EPI_[A-Z]+_[0-9]+$/
 
     annotation = [
@@ -3222,13 +3221,13 @@ class BioSampleValidator < ValidatorBase
     # 有効な値のlocus_tag_prefixとbioproject_idの記述があるか
     attr_list.each do |attr|
       unless attr['locus_tag_prefix'].nil?
-        if !@nullability.null_value?(attr['locus_tag_prefix']) && !@nullability.null_not_recommended_value?(attr['locus_tag_prefix'])
+        if !InsdcNullability.null_value?(attr['locus_tag_prefix']) && !InsdcNullability.null_not_recommended_value?(attr['locus_tag_prefix'])
           edit_locus_tag_prefix = true
         end
         locus_tag_prefix_values.push(attr['locus_tag_prefix'])
       end
       unless attr['bioproject_id'].nil?
-        if !@nullability.null_value?(attr['bioproject_id']) &&  !@nullability.null_not_recommended_value?(attr['bioproject_id'])
+        if !InsdcNullability.null_value?(attr['bioproject_id']) &&  !InsdcNullability.null_not_recommended_value?(attr['bioproject_id'])
           edit_bioproject_id = true
         end
         bioproject_id_values.push(attr['bioproject_id'])
@@ -3261,7 +3260,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def biosample_not_found (rule_code, sample_name, derived_from, submitter_id, line_num)
-    return nil if @nullability.null_value?(derived_from)
+    return nil if InsdcNullability.null_value?(derived_from)
     return nil if submitter_id.nil?
 
     result = true
@@ -3368,7 +3367,7 @@ class BioSampleValidator < ValidatorBase
       if package_name.start_with?(package_prefix) # package名は前方一致でチェック。MIGS.ba"だと"MIGS.ba.human-gut"でもチェック対象
         exist_value = false # 意味のある値が入っているか
         mandatory_attr_list.each do |mandatory_attr|
-          if !@nullability.null_value?(sample_attr[mandatory_attr]) # null相当値(nil, 空白, null_accepted)ではないか
+          if !InsdcNullability.null_value?(sample_attr[mandatory_attr]) # null相当値(nil, 空白, null_accepted)ではないか
             exist_value = true
           end
         end
@@ -3405,7 +3404,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_identical_identifiers_among_organism_strain_isolate (rule_code, sample_name, package_name, organism, strain, isolate, line_num)
-    return nil if package_name.blank? || @nullability.null_value?(organism)
+    return nil if package_name.blank? || InsdcNullability.null_value?(organism)
     result = true
     if package_name.start_with?('MIGS.ba')
       keywords = ['sp.', 'bacterium', 'archaeon']
@@ -3425,9 +3424,9 @@ class BioSampleValidator < ValidatorBase
       # organism名に sp./bacterium/archaeon が含まれている場合、その後の文字列でチェック
       unless organism_sufix == ''
         match_sufix = false # strain or isolate に一致するか
-        if !@nullability.null_value?(strain) && organism_sufix == strain
+        if !InsdcNullability.null_value?(strain) && organism_sufix == strain
           match_sufix = true
-        elsif !@nullability.null_value?(isolate) && organism_sufix == isolate
+        elsif !InsdcNullability.null_value?(isolate) && organism_sufix == isolate
           match_sufix = true
         end
         if match_sufix == false # strain or isolate のいずれにも一致しなければfalse
@@ -3462,7 +3461,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_strain_value (rule_code, sample_name, strain, orgainsm, invalid_value_settings, line_num)
-    return nil if @nullability.null_value?(strain)
+    return nil if InsdcNullability.null_value?(strain)
     result = true
 
     if invalid_value_settings['exact_match'].include?(strain.downcase)
@@ -3474,7 +3473,7 @@ class BioSampleValidator < ValidatorBase
         end
       end
     end
-    if !@nullability.null_value?(orgainsm) && strain.downcase.start_with?(orgainsm.downcase)
+    if !InsdcNullability.null_value?(orgainsm) && strain.downcase.start_with?(orgainsm.downcase)
       result = false
     end
     if result == false
@@ -3509,7 +3508,7 @@ class BioSampleValidator < ValidatorBase
     reporting_level_term_attr_list.each do |reporting_level_term_attr|
       # null相当値である
       attr_value = sample_attr[reporting_level_term_attr]
-      if @nullability.null_value?(attr_value) || @nullability.null_not_recommended_value?(attr_value)
+      if InsdcNullability.null_value?(attr_value) || InsdcNullability.null_not_recommended_value?(attr_value)
         # reporting_level_term ではない
         if !reporting_level_term_list.include?(sample_attr[reporting_level_term_attr])
           # エラー属性名を配列に追加

--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -18,9 +18,8 @@ class BioSampleValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/biosample')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
-    DateFormat.set_config(@conf)
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
+    @date_format = DateFormat.new(@conf)
 
     @error_list = error_list = []
 
@@ -234,13 +233,13 @@ class BioSampleValidator < ValidatorBase
 
       ### organismの検証とtaxonomy_idの確定
       input_taxid = biosample_data['attributes']['taxonomy_id']
-      if input_taxid.nil? || InsdcNullability.null_value?(input_taxid) # taxonomy_idの記述がない("missing"も未記入とみなす)
+      if input_taxid.nil? || @nullability.null_value?(input_taxid) # taxonomy_idの記述がない("missing"も未記入とみなす)
         taxonomy_id = OrganismValidator::TAX_INVALID # tax_idを使用するルールをスキップさせるために無効値をセット
       else
         taxonomy_id = input_taxid
       end
       input_organism = biosample_data['attributes']['organism']
-      if !(input_organism.nil? && InsdcNullability.null_value?(input_organism)) # organismの記述がある("missing"は未記入とみなす)
+      if !(input_organism.nil? && @nullability.null_value?(input_organism)) # organismの記述がある("missing"は未記入とみなす)
         if taxonomy_id != OrganismValidator::TAX_INVALID # tax_idの記述がある
           ret = taxonomy_name_and_id_not_match('BS_R0004', sample_name, taxonomy_id, input_organism, line_num)
         else
@@ -742,7 +741,7 @@ class BioSampleValidator < ValidatorBase
   #
   def missing_sample_name (rule_code, sample_name, biosample_data, line_num)
     return nil if biosample_data.nil? || biosample_data['attributes'].nil?
-    return true unless InsdcNullability.null_value?(biosample_data['attributes']['sample_name'])
+    return true unless @nullability.null_value?(biosample_data['attributes']['sample_name'])
 
     annotation = [
       {key: 'Sample name', value: biosample_data['attributes']['sample_name'].to_s},
@@ -764,7 +763,7 @@ class BioSampleValidator < ValidatorBase
   #
   def missing_organism (rule_code, sample_name, biosample_data, line_num)
     return nil if biosample_data.nil? || biosample_data['attributes'].nil?
-    return true unless InsdcNullability.null_value?(biosample_data['attributes']['organism'])
+    return true unless @nullability.null_value?(biosample_data['attributes']['organism'])
 
     annotation = [
       {key: 'Sample name', value: sample_name},
@@ -928,7 +927,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def attribute_value_not_in_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
 
     result =  true
     if !cv_attr[attr_name].nil? # CVを使用する属性か
@@ -983,7 +982,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_attribute_value_for_controlled_terms (rule_code, sample_name, attr_name, attr_val, cv_attr, line_num)
-    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
 
     # CVを使用しない属性か、CVリストに値があれば OK
     return true if cv_attr[attr_name].nil? || cv_attr[attr_name].include?(attr_val)
@@ -1011,7 +1010,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_publication_identifier (rule_code, sample_name, attr_name, attr_val, ref_attr, line_num)
-    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
 
     result =  true
     if ref_attr.include?(attr_name) # リファレンス型の属性か
@@ -1088,7 +1087,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_accession (rule_code, sample_name, bioproject_accession, line_num)
-    return nil if InsdcNullability.null_value?(bioproject_accession)
+    return nil if @nullability.null_value?(bioproject_accession)
 
     result = true
     if bioproject_accession =~ /^PRJ[D|E|N]\w?\d{1,}$/ || bioproject_accession =~ /^PSUB\d{6}$/
@@ -1126,7 +1125,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_geo_loc_name_format (rule_code, sample_name, geo_loc_name, country_list, line_num)
-    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_not_recommended_value?(geo_loc_name)
+    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_not_recommended_value?(geo_loc_name)
 
     annotated_name = geo_loc_name.sub(/\s*:\s*/, ':') # 最初のコロンの前後の空白を詰める
     # 2つ目以降の":"は", "に置換する
@@ -1186,7 +1185,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_country (rule_code, sample_name, geo_loc_name, country_list, line_num)
-    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_not_recommended_value?(geo_loc_name)
+    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_not_recommended_value?(geo_loc_name)
     country_name = geo_loc_name.split(':').first.strip
     matched_country = country_list.select {|country| country == country_name }
     if matched_country.any?
@@ -1214,7 +1213,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_lat_lon_format (rule_code, sample_name, lat_lon, line_num)
-    return nil if InsdcNullability.null_value?(lat_lon)
+    return nil if @nullability.null_value?(lat_lon)
 
     insdc_latlon = Geolocation.format_insdc_latlon(lat_lon)
     # INSDC の formatに直せなかった場合はnilが返るが、auto-correctはないのでこのメソッドでは無視。これらはBS_R0139でエラーになる。
@@ -1245,7 +1244,7 @@ class BioSampleValidator < ValidatorBase
   # 実際に別の国にいる時だけ warning を返す
   #
   def latlon_versus_country (rule_code, sample_name, geo_loc_name, lat_lon, line_num)
-    return nil if InsdcNullability.null_value?(geo_loc_name) || InsdcNullability.null_value?(lat_lon)
+    return nil if @nullability.null_value?(geo_loc_name) || @nullability.null_value?(lat_lon)
 
     country_name = geo_loc_name.split(':').first.strip
     expected_iso = Geolocation.insdc_to_iso_a3[country_name]
@@ -1290,7 +1289,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_lat_lon (rule_code, sample_name, lat_lon, line_num)
-    return nil if InsdcNullability.null_value?(lat_lon)
+    return nil if @nullability.null_value?(lat_lon)
 
     result = true
     insdc_latlon = Geolocation.format_insdc_latlon(lat_lon)
@@ -1324,7 +1323,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_host_organism_name (rule_code, sample_name, host_taxid, host_name, line_num)
-    return nil if InsdcNullability.null_value?(host_name)
+    return nil if @nullability.null_value?(host_name)
     ret = true
 
     annotation = [
@@ -1414,7 +1413,7 @@ class BioSampleValidator < ValidatorBase
   # taxonomy_idの指定が無かった場合に実行されるため、常にfalseを返す
   #
   def taxonomy_error_warning (rule_code, sample_name, organism_name, line_num)
-    return nil if InsdcNullability.null_value?(organism_name)
+    return nil if @nullability.null_value?(organism_name)
     # あればキャッシュを使用
     if @cache.check(ValidatorCache::EXIST_ORGANISM_NAME, organism_name).nil?
       ret = @org_validator.suggest_taxid_from_name(organism_name)
@@ -1479,7 +1478,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def taxonomy_name_and_id_not_match (rule_code, sample_name, taxonomy_id, organism_name, line_num)
-    return nil if InsdcNullability.null_value?(organism_name) || InsdcNullability.null_value?(taxonomy_id)
+    return nil if @nullability.null_value?(organism_name) || @nullability.null_value?(taxonomy_id)
 
     # あればキャッシュを使用
     if @cache.has_key(ValidatorCache::TAX_MATCH_ORGANISM, taxonomy_id) == false # cache値がnilの可能性があるためhas_keyでチェック
@@ -1520,7 +1519,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def package_versus_organism (rule_code, sample_name, taxonomy_id, package_name, organism, line_num)
-    return nil if package_name.blank? || InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if package_name.blank? || @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
 
     # あればキャッシュを使用
     cache_key = ValidatorCache.create_key(taxonomy_id, package_name)
@@ -1563,7 +1562,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def sex_for_bacteria (rule_code, sample_name, taxonomy_id, sex, organism, line_num)
-    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID || InsdcNullability.null_value?(sex)
+    return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID || @nullability.null_value?(sex)
 
     ret = true
     bac_vir_linages = [OrganismValidator::TAX_BACTERIA, OrganismValidator::TAX_VIRUSES]
@@ -1625,13 +1624,13 @@ class BioSampleValidator < ValidatorBase
     vouchers_list = []
     attr_list.each do |attr|
       unless attr['culture_collection'].nil?
-        vouchers_list.push({attr_name: 'culture_collection', attr_no: attr['attr_no'], value: attr['culture_collection'], institution_code: attr['culture_collection'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['culture_collection'])
+        vouchers_list.push({attr_name: 'culture_collection', attr_no: attr['attr_no'], value: attr['culture_collection'], institution_code: attr['culture_collection'].split(':').first.strip}) unless @nullability.null_value?(attr['culture_collection'])
       end
       unless attr['specimen_voucher'].nil?
-        vouchers_list.push({attr_name: 'specimen_voucher', attr_no: attr['attr_no'], value: attr['specimen_voucher'], institution_code: attr['specimen_voucher'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['specimen_voucher'])
+        vouchers_list.push({attr_name: 'specimen_voucher', attr_no: attr['attr_no'], value: attr['specimen_voucher'], institution_code: attr['specimen_voucher'].split(':').first.strip}) unless @nullability.null_value?(attr['specimen_voucher'])
       end
       unless attr['bio_material'].nil?
-        vouchers_list.push({attr_name: 'bio_material', attr_no: attr['attr_no'], value: attr['bio_material'], institution_code: attr['bio_material'].split(':').first.strip}) unless InsdcNullability.null_value?(attr['bio_material'])
+        vouchers_list.push({attr_name: 'bio_material', attr_no: attr['attr_no'], value: attr['bio_material'], institution_code: attr['bio_material'].split(':').first.strip}) unless @nullability.null_value?(attr['bio_material'])
       end
     end
 
@@ -1689,11 +1688,10 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def future_collection_date (rule_code, sample_name, collection_date, line_num)
-    return nil if InsdcNullability.null_value?(collection_date) || InsdcNullability.null_not_recommended_value?(collection_date)
+    return nil if @nullability.null_value?(collection_date) || @nullability.null_not_recommended_value?(collection_date)
     result = nil
     # DDBJ 日付型へのフォーマットを試みる
-    df = DateFormat.new
-    collection_date = df.format_date2ddbj(collection_date)
+    collection_date = @date_format.format_date2ddbj(collection_date)
     @conf[:ddbj_date_format].each do |format|
       parse_format = format['parse_date_format']
 
@@ -1826,26 +1824,25 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime_format (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num)
-    return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil if attr_name.blank? || @nullability.null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) # 日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
-    return nil if attr_name == 'collection_date' && (InsdcNullability.null_not_recommended_value?(attr_val))
+    return nil if attr_name == 'collection_date' && (@nullability.null_not_recommended_value?(attr_val))
 
     attr_val_org = attr_val
     result = true
 
     # DDBJ 日付型へのフォーマットを試みる
-    df = DateFormat.new
-    attr_val = df.format_date2ddbj(attr_val)
+    attr_val = @date_format.format_date2ddbj(attr_val)
 
     # 補正後の値が妥当な日付、フォーマットであるかチェックする
-    is_ddbj_format = df.ddbj_date_format?(attr_val) # DDBJフォーマットであるか
-    parsable_date = df.parsable_date_format?(attr_val) # 妥当な日付であるか(2018/13/34 => false)
+    is_ddbj_format = @date_format.ddbj_date_format?(attr_val) # DDBJフォーマットであるか
+    parsable_date = @date_format.parsable_date_format?(attr_val) # 妥当な日付であるか(2018/13/34 => false)
 
     if !is_ddbj_format || !parsable_date # 無効なフォーマットであれば中途半端な補正はせず元の入力値に戻す
       attr_val = attr_val_org
     else # timezoneをUTC時間に変更
-      attr_val = df.convert2utc(attr_val)
+      attr_val = @date_format.convert2utc(attr_val)
     end
 
     # 置換が発生した場合だけwarningを出す
@@ -1882,15 +1879,14 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_datetime (rule_code, sample_name, attr_name, attr_val, ts_attr, line_num)
-    return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil if attr_name.blank? || @nullability.null_value?(attr_val)
     return nil unless ts_attr.include?(attr_name) # 日付型の属性でなければスキップ
     # collection_dateは reporting level term属性なので "n.a." => "missing"への置換が行われない。"n.a."でもチェックスキップする
-    return nil if attr_name == 'collection_date' && (InsdcNullability.null_not_recommended_value?(attr_val))
+    return nil if attr_name == 'collection_date' && (@nullability.null_not_recommended_value?(attr_val))
 
     result = true
-    df = DateFormat.new
-    is_ddbj_format = df.ddbj_date_format?(attr_val) # DDBJフォーマットであるか
-    parsable_date = df.parsable_date_format?(attr_val) # 妥当な日付であるか(2018/13/34 => false)
+    is_ddbj_format = @date_format.ddbj_date_format?(attr_val) # DDBJフォーマットであるか
+    parsable_date = @date_format.parsable_date_format?(attr_val) # 妥当な日付であるか(2018/13/34 => false)
     if !(is_ddbj_format && parsable_date) # DDBJフォーマットであるか
       result = false
       annotation = [
@@ -1922,7 +1918,7 @@ class BioSampleValidator < ValidatorBase
       return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == 'attr_value' # 属性値の検証
-      return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+      return nil if attr_name.blank? || @nullability.null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -1983,12 +1979,12 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def redundant_taxonomy_attributes (rule_code, sample_name, organism, host, isolation_source, line_num)
-    return nil  if InsdcNullability.null_value?(organism) && InsdcNullability.null_value?(host) && InsdcNullability.null_value?(isolation_source)
+    return nil  if @nullability.null_value?(organism) && @nullability.null_value?(host) && @nullability.null_value?(isolation_source)
 
     taxon_values = []
-    taxon_values.push(organism) unless InsdcNullability.null_value?(organism)
-    taxon_values.push(host) unless InsdcNullability.null_value?(host)
-    taxon_values.push(isolation_source) unless InsdcNullability.null_value?(isolation_source)
+    taxon_values.push(organism) unless @nullability.null_value?(organism)
+    taxon_values.push(host) unless @nullability.null_value?(host)
+    taxon_values.push(isolation_source) unless @nullability.null_value?(isolation_source)
     uniq_taxon_values = taxon_values.map {|tax_name|
       tax_name.strip.gsub(' ', '').downcase
     }.uniq
@@ -2028,7 +2024,7 @@ class BioSampleValidator < ValidatorBase
       return nil if attr_name.blank?
       replaced = attr_name.dup
     elsif target == 'attr_value' # 属性値の検証
-      return nil if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+      return nil if attr_name.blank? || @nullability.null_value?(attr_val)
       replaced = attr_val.dup
     else
       return nil
@@ -2085,7 +2081,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_ascii_attribute_value (rule_code, sample_name, attr_name, attr_val, line_num)
-    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
     return true if attr_val.ascii_only?
 
     # 属性値のどこにnon ascii文字があるか示すメッセージを作成
@@ -2154,7 +2150,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def bioproject_not_found (rule_code, sample_name, bioproject_accession, submitter_id, line_num)
-    return nil if InsdcNullability.null_value?(bioproject_accession)
+    return nil if @nullability.null_value?(bioproject_accession)
     return nil if submitter_id.nil?
 
     # cache 値が nil の可能性があるため has_key で判定する
@@ -2251,7 +2247,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bioproject_type (rule_code, sample_name, bioproject_accession, line_num)
-    return nil if InsdcNullability.null_value?(bioproject_accession)
+    return nil if @nullability.null_value?(bioproject_accession)
 
     if @cache.check(ValidatorCache::IS_UMBRELLA_ID, bioproject_accession).nil?
       is_umbrella = @db_validator.umbrella_project?(bioproject_accession)
@@ -2283,7 +2279,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_integer_attribute_value (rule_code, sample_name, attr_name, attr_val, int_attr, line_num)
-    return nil  if attr_name.blank? || InsdcNullability.null_value?(attr_val)
+    return nil  if attr_name.blank? || @nullability.null_value?(attr_val)
     # 整数型の属性であり有効な入力値がある場合だけチェック
     return true unless int_attr.include?(attr_name)
 
@@ -2406,7 +2402,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def duplicated_locus_tag_prefix (rule_code, sample_name, locus_tag, biosample_list, submission_id, line_num)
-    return nil if InsdcNullability.null_value?(locus_tag)
+    return nil if @nullability.null_value?(locus_tag)
     result = true
 
     # 同一ファイル内での重複チェック
@@ -2455,7 +2451,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def bioproject_submission_id_replacement (rule_code, sample_name, psub_id, line_num)
-    return nil if InsdcNullability.null_value?(psub_id)
+    return nil if @nullability.null_value?(psub_id)
     result = true
 
     if /^PSUB/ =~ psub_id
@@ -2501,7 +2497,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, sample_name, taxonomy_id, organism, line_num)
-    return nil if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
     result = @org_validator.is_infraspecific_rank(taxonomy_id)
     if result == false
       annotation = [
@@ -2568,7 +2564,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_locus_tag_prefix_format (rule_code, sample_name, locus_tag, line_num)
-    return nil  if InsdcNullability.null_value?(locus_tag)
+    return nil  if @nullability.null_value?(locus_tag)
     return true if locus_tag.size.between?(3, 12) && locus_tag =~ /^[0-9a-zA-Z]+$/ && locus_tag !~ /^[0-9]+/
 
     annotation = [
@@ -2637,7 +2633,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_sample_name_format (rule_code, sample_name, line_num)
-    return nil  if InsdcNullability.null_value?(sample_name)
+    return nil  if @nullability.null_value?(sample_name)
     return true if sample_name.size <= 100 && sample_name =~ /^[0-9a-zA-Z\s\(\)\{\}\[\]\+\-_.]+$/  # 最大100文字で英数字、空白、記号 (){}[]+-_. から構成されること
 
     annotation = [
@@ -2663,12 +2659,12 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_taxonomy_for_genome_sample (rule_code, sample_name, package_name, taxonomy_id, organism, line_num)
-    return nil if package_name.blank? || InsdcNullability.null_value?(organism)
+    return nil if package_name.blank? || @nullability.null_value?(organism)
     result = true
     if package_name.start_with?('MIGS.ba') || package_name.start_with?('MIGS.eu')
       # "sp."終わり、または"xxx sp. (in: yyy)", "xxx sp. (ex yyy)"であればエラー seealso: https://ddbj-dev.atlassian.net/browse/VALIDATOR-14
       if organism.downcase.end_with?('sp.') || organism =~ /.+sp\.\s*\((in\:|ex)\s.*\)$/
-        if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+        if @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
           # tax_idが不明な場合、新規生物種登録の可能性がありstrain名をつけてもらいたいためエラー
           result = false
         else
@@ -2701,7 +2697,7 @@ class BioSampleValidator < ValidatorBase
   # ==== Return
   # true/false
   def taxonomy_warning (rule_code, sample_name, component_organism, attr_no, line_num)
-    return nil if InsdcNullability.null_value?(component_organism)
+    return nil if @nullability.null_value?(component_organism)
     ret = true
 
     annotation = [
@@ -2755,7 +2751,7 @@ class BioSampleValidator < ValidatorBase
   # ==== Return
   # true/false
   def invalid_metagenome_source (rule_code, sample_name, metagenome_source, attr_idx, line_num)
-    return nil if InsdcNullability.null_value?(metagenome_source)
+    return nil if @nullability.null_value?(metagenome_source)
     ret = true
 
     metagenome_linages = [OrganismValidator::TAX_METAGENOMES]
@@ -2820,7 +2816,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_culture_collection_format (rule_code, sample_name, culture_collection, line_num)
-    return nil if InsdcNullability.null_value?(culture_collection)
+    return nil if @nullability.null_value?(culture_collection)
 
     ret = true
     if culture_collection.split(':').size < 2 || culture_collection.split(':').size > 3
@@ -2849,7 +2845,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_culture_collection (rule_code, sample_name, culture_collection, institution_list, attr_idx, line_num)
-    return nil if InsdcNullability.null_value?(culture_collection) || institution_list.nil?
+    return nil if @nullability.null_value?(culture_collection) || institution_list.nil?
     return nil if culture_collection.split(':').size < 2 || culture_collection.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'culture_collection', culture_collection, institution_list, attr_idx, line_num)
@@ -2869,7 +2865,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def specimen_voucher_for_bacteria_and_unclassified_sequences (rule_code, sample_name, specimen_voucher, taxonomy_id, line_num)
-    return nil if InsdcNullability.null_value?(specimen_voucher) ||  InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return nil if @nullability.null_value?(specimen_voucher) ||  @nullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
 
     ret = @org_validator.target_organism_for_specimen_voucher?(taxonomy_id)
     if ret == false
@@ -2896,7 +2892,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_specimen_voucher_format (rule_code, sample_name, specimen_voucher, line_num)
-    return nil if InsdcNullability.null_value?(specimen_voucher)
+    return nil if @nullability.null_value?(specimen_voucher)
 
     ret = true
     if specimen_voucher.split(':').size > 3 # <institution-code>と<collection-code>共に省略可能なので、区切り文字(":")が多くないかだけチェック
@@ -2925,7 +2921,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_specimen_voucher (rule_code, sample_name, specimen_voucher, institution_list, attr_idx, line_num)
-    return nil if InsdcNullability.null_value?(specimen_voucher) || institution_list.nil?
+    return nil if @nullability.null_value?(specimen_voucher) || institution_list.nil?
     return nil if specimen_voucher.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'specimen_voucher', specimen_voucher, institution_list, attr_idx, line_num)
@@ -2944,7 +2940,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bio_material_format (rule_code, sample_name, bio_material, line_num)
-    return nil if InsdcNullability.null_value?(bio_material)
+    return nil if @nullability.null_value?(bio_material)
 
     ret = true
     if bio_material.split(':').size > 3 # <institution-code>と<collection-code>共に省略可能なので、区切り文字(":")が多くないかだけチェック
@@ -2972,7 +2968,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_bio_material (rule_code, sample_name, bio_material, institution_list, line_num)
-    return nil if InsdcNullability.null_value?(bio_material) || institution_list.nil?
+    return nil if @nullability.null_value?(bio_material) || institution_list.nil?
     return nil if bio_material.split(':').size > 3
 
     invalid_institude_name(rule_code, sample_name, 'bio_material', bio_material, institution_list, nil, line_num)
@@ -3099,7 +3095,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_gisaid_accession (rule_code, sample_name, gisaid_accession, line_num)
-    return nil  if InsdcNullability.null_value?(gisaid_accession)
+    return nil  if @nullability.null_value?(gisaid_accession)
     return true if gisaid_accession =~ /^EPI_[A-Z]+_[0-9]+$/
 
     annotation = [
@@ -3226,13 +3222,13 @@ class BioSampleValidator < ValidatorBase
     # 有効な値のlocus_tag_prefixとbioproject_idの記述があるか
     attr_list.each do |attr|
       unless attr['locus_tag_prefix'].nil?
-        if !InsdcNullability.null_value?(attr['locus_tag_prefix']) && !InsdcNullability.null_not_recommended_value?(attr['locus_tag_prefix'])
+        if !@nullability.null_value?(attr['locus_tag_prefix']) && !@nullability.null_not_recommended_value?(attr['locus_tag_prefix'])
           edit_locus_tag_prefix = true
         end
         locus_tag_prefix_values.push(attr['locus_tag_prefix'])
       end
       unless attr['bioproject_id'].nil?
-        if !InsdcNullability.null_value?(attr['bioproject_id']) &&  !InsdcNullability.null_not_recommended_value?(attr['bioproject_id'])
+        if !@nullability.null_value?(attr['bioproject_id']) &&  !@nullability.null_not_recommended_value?(attr['bioproject_id'])
           edit_bioproject_id = true
         end
         bioproject_id_values.push(attr['bioproject_id'])
@@ -3265,7 +3261,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def biosample_not_found (rule_code, sample_name, derived_from, submitter_id, line_num)
-    return nil if InsdcNullability.null_value?(derived_from)
+    return nil if @nullability.null_value?(derived_from)
     return nil if submitter_id.nil?
 
     result = true
@@ -3372,7 +3368,7 @@ class BioSampleValidator < ValidatorBase
       if package_name.start_with?(package_prefix) # package名は前方一致でチェック。MIGS.ba"だと"MIGS.ba.human-gut"でもチェック対象
         exist_value = false # 意味のある値が入っているか
         mandatory_attr_list.each do |mandatory_attr|
-          if !InsdcNullability.null_value?(sample_attr[mandatory_attr]) # null相当値(nil, 空白, null_accepted)ではないか
+          if !@nullability.null_value?(sample_attr[mandatory_attr]) # null相当値(nil, 空白, null_accepted)ではないか
             exist_value = true
           end
         end
@@ -3409,7 +3405,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def non_identical_identifiers_among_organism_strain_isolate (rule_code, sample_name, package_name, organism, strain, isolate, line_num)
-    return nil if package_name.blank? || InsdcNullability.null_value?(organism)
+    return nil if package_name.blank? || @nullability.null_value?(organism)
     result = true
     if package_name.start_with?('MIGS.ba')
       keywords = ['sp.', 'bacterium', 'archaeon']
@@ -3429,9 +3425,9 @@ class BioSampleValidator < ValidatorBase
       # organism名に sp./bacterium/archaeon が含まれている場合、その後の文字列でチェック
       unless organism_sufix == ''
         match_sufix = false # strain or isolate に一致するか
-        if !InsdcNullability.null_value?(strain) && organism_sufix == strain
+        if !@nullability.null_value?(strain) && organism_sufix == strain
           match_sufix = true
-        elsif !InsdcNullability.null_value?(isolate) && organism_sufix == isolate
+        elsif !@nullability.null_value?(isolate) && organism_sufix == isolate
           match_sufix = true
         end
         if match_sufix == false # strain or isolate のいずれにも一致しなければfalse
@@ -3466,7 +3462,7 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def invalid_strain_value (rule_code, sample_name, strain, orgainsm, invalid_value_settings, line_num)
-    return nil if InsdcNullability.null_value?(strain)
+    return nil if @nullability.null_value?(strain)
     result = true
 
     if invalid_value_settings['exact_match'].include?(strain.downcase)
@@ -3478,7 +3474,7 @@ class BioSampleValidator < ValidatorBase
         end
       end
     end
-    if !InsdcNullability.null_value?(orgainsm) && strain.downcase.start_with?(orgainsm.downcase)
+    if !@nullability.null_value?(orgainsm) && strain.downcase.start_with?(orgainsm.downcase)
       result = false
     end
     if result == false
@@ -3513,7 +3509,7 @@ class BioSampleValidator < ValidatorBase
     reporting_level_term_attr_list.each do |reporting_level_term_attr|
       # null相当値である
       attr_value = sample_attr[reporting_level_term_attr]
-      if InsdcNullability.null_value?(attr_value) || InsdcNullability.null_not_recommended_value?(attr_value)
+      if @nullability.null_value?(attr_value) || @nullability.null_not_recommended_value?(attr_value)
         # reporting_level_term ではない
         if !reporting_level_term_list.include?(sample_attr[reporting_level_term_attr])
           # エラー属性名を配列に追加

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -10,8 +10,7 @@ class CombinationValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -10,7 +10,6 @@ class CombinationValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/common/date_format.rb
+++ b/lib/validator/common/date_format.rb
@@ -1,9 +1,9 @@
 require 'date'
 
 class DateFormat
-  def self.set_config (config_obj)
-    @@convert_date_format = config_obj[:convert_date_format]
-    @@ddbj_date_format = config_obj[:ddbj_date_format]
+  def initialize(config_obj)
+    @convert_date_format = config_obj[:convert_date_format]
+    @ddbj_date_format = config_obj[:ddbj_date_format]
   end
 
   #
@@ -265,7 +265,7 @@ class DateFormat
   # returns: 置換後の文字列 "2014-03-02"
   #
   def format_delimiter_single_date(date_text, date_text_org)
-    @@convert_date_format.each do |format|
+    @convert_date_format.each do |format|
       regex = Regexp.new(format['regex'])
       ## single date format  e.g.) YYYY-MM-DD
       if regex.match(date_text)
@@ -297,7 +297,7 @@ class DateFormat
   # returns: 置換後の文字列 "2014-10-24/2014-10-25"
   #
   def format_delimiter_range_date(date_text, date_text_org)
-    @@convert_date_format.each do |format|
+    @convert_date_format.each do |format|
       ## range date format  e.g.) YYYY-MM-DD / YYYY-MM-DD
       range_format = format['regex'][1..-2] # 行末行頭の^と$を除去
       range_regex = Regexp.new("(?<start>#{range_format})\s*/\s*(?<end>#{range_format})") # "/"で連結
@@ -342,7 +342,7 @@ class DateFormat
   def parsable_date_format?(date_text)
     return false if date_text.nil?
     parsable_date = true
-    @@ddbj_date_format.each do |format|
+    @ddbj_date_format.each do |format|
       regex_simple = Regexp.new(format['regex']) # 範囲ではない
       regex_range = Regexp.new("(?<start>#{format["regex"][1..-2]})\s*/\s*(?<end>#{format["regex"][1..-2]})") # 範囲での記述
       begin
@@ -382,7 +382,7 @@ class DateFormat
   def ddbj_date_format? (date_text)
     return nil if date_text.nil?
     result = false
-    @@ddbj_date_format.each do |format|
+    @ddbj_date_format.each do |format|
       ## single date format
       regex = Regexp.new(format['regex'])
       if date_text =~ regex
@@ -446,7 +446,7 @@ class DateFormat
   # returns UTCに直した日付表現 "2016-07-10T09:00:01Z", "2016-07-10T09:00:01+09:00/2016-07-10T10:00:01+09:00"
   #
   def convert2utc(date_text)
-    @@ddbj_date_format.each do |format|
+    @ddbj_date_format.each do |format|
       regex_simple = Regexp.new(format['regex']) # 範囲ではない
       regex_range = Regexp.new("(?<start>#{format["regex"][1..-2]})\s*/\s*(?<end>#{format["regex"][1..-2]})") # 範囲での記述
       if date_text =~ regex_simple

--- a/lib/validator/common/insdc_nullability.rb
+++ b/lib/validator/common/insdc_nullability.rb
@@ -4,29 +4,31 @@ require 'active_support/core_ext/object/blank'
 # 判定するユーティリティ。設定ファイル (null_accepted.json / null_not_recommended.json)
 # から正規表現リストが与えられる。
 #
-# 各 validator の初期化で `InsdcNullability.null_accepted=` と
-# `InsdcNullability.null_not_recommended=` を設定する。
-module InsdcNullability
-  class << self
-    attr_accessor :null_accepted, :null_not_recommended
+# 各 validator が `null_accepted` / `null_not_recommended` を引数にインスタンスを生成する。
+# 過去は module + class-accessor だったが、validator 種別ごとに list が違うため
+# thread safety を確保すべくインスタンス state に移した。
+class InsdcNullability
+  def initialize(null_accepted:, null_not_recommended:)
+    @null_accepted = null_accepted
+    @null_not_recommended = null_not_recommended
   end
 
   #
   # nil, 空白, "missing: ...", "not applicable" など null 定義に該当するなら true。
   #
-  def self.null_value? (value)
+  def null_value?(value)
     return true if value.blank?
 
-    null_accepted.any? { value =~ /^(#{it})$/i }
+    @null_accepted.any? { value =~ /^(#{it})$/i }
   end
 
   #
   # "NA" (case insensitive) 等、推奨されない null 表現なら true。
   #
-  def self.null_not_recommended_value? (value)
+  def null_not_recommended_value?(value)
     return false if value.blank?
 
-    null_not_recommended.any? { value =~ /^(#{it})$/i }
+    @null_not_recommended.any? { value =~ /^(#{it})$/i }
   end
 
   #
@@ -34,14 +36,14 @@ module InsdcNullability
   # (英数字2文字以上) が残らなければ true。
   # allow_reporting_term=true の場合は "missing: ..." を許容する。
   #
-  def self.meaningless_value? (value, allow_reporting_term = false)
+  def meaningless_value?(value, allow_reporting_term = false)
     return false if value.blank?
-    return true  if null_not_recommended.any? { value =~ /^(#{it})$/i }
+    return true  if @null_not_recommended.any? { value =~ /^(#{it})$/i }
 
-    accepted = allow_reporting_term ? null_accepted.reject { it.start_with?('missing:') } : null_accepted
+    accepted = allow_reporting_term ? @null_accepted.reject { it.start_with?('missing:') } : @null_accepted
     return true if accepted.any? { value =~ /^(#{it})$/i }
 
-    stripped = (accepted + null_not_recommended).inject(value) {|s, n| s.gsub(/#{n}/i, '') }
+    stripped = (accepted + @null_not_recommended).inject(value) {|s, n| s.gsub(/#{n}/i, '') }
     stripped.split(' ').none? { it.scan(/[0-9a-zA-Z]/).length >= 2 }
   end
 end

--- a/lib/validator/common/insdc_nullability.rb
+++ b/lib/validator/common/insdc_nullability.rb
@@ -1,34 +1,30 @@
 require 'active_support/core_ext/object/blank'
 
 # INSDC で null 相当の表現 ("missing: control sample", "not applicable", "NA" 等) を
-# 判定するユーティリティ。設定ファイル (null_accepted.json / null_not_recommended.json)
-# から正規表現リストが与えられる。
-#
-# 各 validator が `null_accepted` / `null_not_recommended` を引数にインスタンスを生成する。
-# 過去は module + class-accessor だったが、validator 種別ごとに list が違うため
-# thread safety を確保すべくインスタンス state に移した。
-class InsdcNullability
-  def initialize(null_accepted:, null_not_recommended:)
-    @null_accepted = null_accepted
-    @null_not_recommended = null_not_recommended
-  end
+# 判定するユーティリティ。`conf/biosample/null_accepted.json` と
+# `conf/biosample/null_not_recommended.json` をクラスロード時に一度だけ読み込み、
+# frozen 配列で保持する (起動後は read-only なので thread safe)。
+module InsdcNullability
+  CONF_DIR             = Rails.root.join('conf/biosample').freeze
+  NULL_ACCEPTED        = JSON.parse(File.read(CONF_DIR.join('null_accepted.json'))).freeze
+  NULL_NOT_RECOMMENDED = JSON.parse(File.read(CONF_DIR.join('null_not_recommended.json'))).freeze
 
   #
   # nil, 空白, "missing: ...", "not applicable" など null 定義に該当するなら true。
   #
-  def null_value?(value)
+  def self.null_value?(value)
     return true if value.blank?
 
-    @null_accepted.any? { value =~ /^(#{it})$/i }
+    NULL_ACCEPTED.any? { value =~ /^(#{it})$/i }
   end
 
   #
   # "NA" (case insensitive) 等、推奨されない null 表現なら true。
   #
-  def null_not_recommended_value?(value)
+  def self.null_not_recommended_value?(value)
     return false if value.blank?
 
-    @null_not_recommended.any? { value =~ /^(#{it})$/i }
+    NULL_NOT_RECOMMENDED.any? { value =~ /^(#{it})$/i }
   end
 
   #
@@ -36,14 +32,14 @@ class InsdcNullability
   # (英数字2文字以上) が残らなければ true。
   # allow_reporting_term=true の場合は "missing: ..." を許容する。
   #
-  def meaningless_value?(value, allow_reporting_term = false)
+  def self.meaningless_value?(value, allow_reporting_term = false)
     return false if value.blank?
-    return true  if @null_not_recommended.any? { value =~ /^(#{it})$/i }
+    return true  if NULL_NOT_RECOMMENDED.any? { value =~ /^(#{it})$/i }
 
-    accepted = allow_reporting_term ? @null_accepted.reject { it.start_with?('missing:') } : @null_accepted
+    accepted = allow_reporting_term ? NULL_ACCEPTED.reject { it.start_with?('missing:') } : NULL_ACCEPTED
     return true if accepted.any? { value =~ /^(#{it})$/i }
 
-    stripped = (accepted + @null_not_recommended).inject(value) {|s, n| s.gsub(/#{n}/i, '') }
+    stripped = (accepted + NULL_NOT_RECOMMENDED).inject(value) {|s, n| s.gsub(/#{n}/i, '') }
     stripped.split(' ').none? { it.scan(/[0-9a-zA-Z]/).length >= 2 }
   end
 end

--- a/lib/validator/common/tsv_field_validator.rb
+++ b/lib/validator/common/tsv_field_validator.rb
@@ -64,7 +64,7 @@ class TsvFieldValidator
     data.each_with_index do |row, field_idx|
       next unless mandatory_field_list.include?(row['key']) # ここではmandatory fieldのみ置換する。optional fieldは空白に置換されるため
       row['values'].each_with_index do |value, value_idx|
-        next if InsdcNullability.null_value?(value) # 既に推奨NULL表現
+        next if value.blank? || null_accepted_list.any? { value =~ /^(#{it})$/i } # 既に推奨NULL表現
         replace_value = ''
         # 推奨されている NULL 値の表記を揃える(小文字表記へ)
         null_accepted_list.each do |null_accepted|

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -10,8 +10,7 @@ class ExperimentValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -10,7 +10,6 @@ class ExperimentValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -11,8 +11,7 @@ class MetaboBankIdfValidator < ValidatorBase
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_idf')))
     @conf[:null_accepted] = @conf[:field_settings]['null_value']['value_list']
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -10,8 +10,6 @@ class MetaboBankIdfValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_idf')))
-    @conf[:null_accepted] = @conf[:field_settings]['null_value']['value_list']
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -10,7 +10,6 @@ class MetaboBankSdrfValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_sdrf')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -10,8 +10,7 @@ class MetaboBankSdrfValidator < ValidatorBase
   def initialize
     super()
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_sdrf')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -10,7 +10,6 @@ class RunValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -10,8 +10,7 @@ class RunValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -10,8 +10,7 @@ class SubmissionValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    InsdcNullability.null_accepted        = @conf[:null_accepted]
-    InsdcNullability.null_not_recommended = @conf[:null_not_recommended]
+    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -10,7 +10,6 @@ class SubmissionValidator < ValidatorBase
   def initialize
     super
     @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
-    @nullability = InsdcNullability.new(null_accepted: @conf[:null_accepted], null_not_recommended: @conf[:null_not_recommended])
 
     @error_list = error_list = []
 

--- a/test/lib/validator/common/date_format_test.rb
+++ b/test/lib/validator/common/date_format_test.rb
@@ -4,11 +4,10 @@ require 'validator/common/date_format'
 class TestDateFormat < Minitest::Test
   def setup
     conf_dir = File.expand_path('../../../../../conf/biosample', __FILE__)
-    @df = DateFormat.new
-    config_obj = {}
-    config_obj[:convert_date_format] = JSON.parse(File.read("#{conf_dir}/convert_date_format.json"))
-    config_obj[:ddbj_date_format] = JSON.parse(File.read("#{conf_dir}/ddbj_date_format.json"))
-    DateFormat.set_config (config_obj)
+    @df = DateFormat.new(
+      convert_date_format: JSON.parse(File.read("#{conf_dir}/convert_date_format.json")),
+      ddbj_date_format:    JSON.parse(File.read("#{conf_dir}/ddbj_date_format.json"))
+    )
   end
 
   def test_format_date2ddbj

--- a/test/lib/validator/common/insdc_nullability_test.rb
+++ b/test/lib/validator/common/insdc_nullability_test.rb
@@ -2,56 +2,48 @@ require 'test_helper'
 require 'validator/common/insdc_nullability'
 
 class TestInsdcNullability < Minitest::Test
-  def setup
-    conf_dir = File.expand_path('../../../../../conf/biosample', __FILE__)
-    @nullability = InsdcNullability.new(
-      null_accepted:        JSON.parse(File.read("#{conf_dir}/null_accepted.json")),
-      null_not_recommended: JSON.parse(File.read("#{conf_dir}/null_not_recommended.json"))
-    )
-  end
-
   def test_null_value?
-    assert_equal true,  @nullability.null_value?(nil)
-    assert_equal true,  @nullability.null_value?('')
-    assert_equal true,  @nullability.null_value?('  ')
-    assert_equal true,  @nullability.null_value?('missing: control sample')
-    assert_equal true,  @nullability.null_value?('missing: data agreement established pre-2023')
-    assert_equal true,  @nullability.null_value?('not applicable')
-    assert_equal true,  @nullability.null_value?('missing')
-    assert_equal false, @nullability.null_value?('aaa')
+    assert_equal true,  InsdcNullability.null_value?(nil)
+    assert_equal true,  InsdcNullability.null_value?('')
+    assert_equal true,  InsdcNullability.null_value?('  ')
+    assert_equal true,  InsdcNullability.null_value?('missing: control sample')
+    assert_equal true,  InsdcNullability.null_value?('missing: data agreement established pre-2023')
+    assert_equal true,  InsdcNullability.null_value?('not applicable')
+    assert_equal true,  InsdcNullability.null_value?('missing')
+    assert_equal false, InsdcNullability.null_value?('aaa')
   end
 
   def test_null_not_recommended_value?
     # 設定値の完全一致は not recommended
-    assert_equal true,  @nullability.null_not_recommended_value?('NA')
-    assert_equal true,  @nullability.null_not_recommended_value?('na')
+    assert_equal true,  InsdcNullability.null_not_recommended_value?('NA')
+    assert_equal true,  InsdcNullability.null_not_recommended_value?('na')
     # 許容された null 値
-    assert_equal false, @nullability.null_not_recommended_value?('missing: control sample')
+    assert_equal false, InsdcNullability.null_not_recommended_value?('missing: control sample')
     # 許容された null 値の case insensitive
-    assert_equal false, @nullability.null_not_recommended_value?('Missing')
+    assert_equal false, InsdcNullability.null_not_recommended_value?('Missing')
     # 空白は感知しない (他でチェック)
-    assert_equal false, @nullability.null_not_recommended_value?('')
+    assert_equal false, InsdcNullability.null_not_recommended_value?('')
   end
 
   def test_meaningless_value?
     # 許容されない null 値
-    assert_equal true,  @nullability.meaningless_value?('NA')
+    assert_equal true,  InsdcNullability.meaningless_value?('NA')
     # 許容された null 値も null 相当値とみなす
-    assert_equal true,  @nullability.meaningless_value?('Missing')
+    assert_equal true,  InsdcNullability.meaningless_value?('Missing')
     # reporting_term を許容しない (第二引数を false または指定しない)
-    assert_equal true,  @nullability.meaningless_value?('missing: control sample')
+    assert_equal true,  InsdcNullability.meaningless_value?('missing: control sample')
     # null 相当値を除去すると意味のない値になるとみなす値
     # "missing: Not collected" は "missing" と "not collected" が除去されて ": " になり、意味のないものと判定される
-    assert_equal true,  @nullability.meaningless_value?('missing: Not collected')
-    assert_equal true,  @nullability.meaningless_value?('missing:')
+    assert_equal true,  InsdcNullability.meaningless_value?('missing: Not collected')
+    assert_equal true,  InsdcNullability.meaningless_value?('missing:')
 
     # 意味のあるとみなされる値
-    assert_equal false, @nullability.meaningless_value?('B1')
-    assert_equal false, @nullability.meaningless_value?('B-1')
-    assert_equal false, @nullability.meaningless_value?('missing: YP')
+    assert_equal false, InsdcNullability.meaningless_value?('B1')
+    assert_equal false, InsdcNullability.meaningless_value?('B-1')
+    assert_equal false, InsdcNullability.meaningless_value?('missing: YP')
     # reporting_term を許容するように第二引数を true にする
-    assert_equal false, @nullability.meaningless_value?('missing: control sample', true)
+    assert_equal false, InsdcNullability.meaningless_value?('missing: control sample', true)
     # 空白は感知しない (他でチェック)
-    assert_equal false, @nullability.null_not_recommended_value?('')
+    assert_equal false, InsdcNullability.null_not_recommended_value?('')
   end
 end

--- a/test/lib/validator/common/insdc_nullability_test.rb
+++ b/test/lib/validator/common/insdc_nullability_test.rb
@@ -4,52 +4,54 @@ require 'validator/common/insdc_nullability'
 class TestInsdcNullability < Minitest::Test
   def setup
     conf_dir = File.expand_path('../../../../../conf/biosample', __FILE__)
-    InsdcNullability.null_accepted        = JSON.parse(File.read("#{conf_dir}/null_accepted.json"))
-    InsdcNullability.null_not_recommended = JSON.parse(File.read("#{conf_dir}/null_not_recommended.json"))
+    @nullability = InsdcNullability.new(
+      null_accepted:        JSON.parse(File.read("#{conf_dir}/null_accepted.json")),
+      null_not_recommended: JSON.parse(File.read("#{conf_dir}/null_not_recommended.json"))
+    )
   end
 
   def test_null_value?
-    assert_equal true,  InsdcNullability.null_value?(nil)
-    assert_equal true,  InsdcNullability.null_value?('')
-    assert_equal true,  InsdcNullability.null_value?('  ')
-    assert_equal true,  InsdcNullability.null_value?('missing: control sample')
-    assert_equal true,  InsdcNullability.null_value?('missing: data agreement established pre-2023')
-    assert_equal true,  InsdcNullability.null_value?('not applicable')
-    assert_equal true,  InsdcNullability.null_value?('missing')
-    assert_equal false, InsdcNullability.null_value?('aaa')
+    assert_equal true,  @nullability.null_value?(nil)
+    assert_equal true,  @nullability.null_value?('')
+    assert_equal true,  @nullability.null_value?('  ')
+    assert_equal true,  @nullability.null_value?('missing: control sample')
+    assert_equal true,  @nullability.null_value?('missing: data agreement established pre-2023')
+    assert_equal true,  @nullability.null_value?('not applicable')
+    assert_equal true,  @nullability.null_value?('missing')
+    assert_equal false, @nullability.null_value?('aaa')
   end
 
   def test_null_not_recommended_value?
     # 設定値の完全一致は not recommended
-    assert_equal true,  InsdcNullability.null_not_recommended_value?('NA')
-    assert_equal true,  InsdcNullability.null_not_recommended_value?('na')
+    assert_equal true,  @nullability.null_not_recommended_value?('NA')
+    assert_equal true,  @nullability.null_not_recommended_value?('na')
     # 許容された null 値
-    assert_equal false, InsdcNullability.null_not_recommended_value?('missing: control sample')
+    assert_equal false, @nullability.null_not_recommended_value?('missing: control sample')
     # 許容された null 値の case insensitive
-    assert_equal false, InsdcNullability.null_not_recommended_value?('Missing')
+    assert_equal false, @nullability.null_not_recommended_value?('Missing')
     # 空白は感知しない (他でチェック)
-    assert_equal false, InsdcNullability.null_not_recommended_value?('')
+    assert_equal false, @nullability.null_not_recommended_value?('')
   end
 
   def test_meaningless_value?
     # 許容されない null 値
-    assert_equal true,  InsdcNullability.meaningless_value?('NA')
+    assert_equal true,  @nullability.meaningless_value?('NA')
     # 許容された null 値も null 相当値とみなす
-    assert_equal true,  InsdcNullability.meaningless_value?('Missing')
+    assert_equal true,  @nullability.meaningless_value?('Missing')
     # reporting_term を許容しない (第二引数を false または指定しない)
-    assert_equal true,  InsdcNullability.meaningless_value?('missing: control sample')
+    assert_equal true,  @nullability.meaningless_value?('missing: control sample')
     # null 相当値を除去すると意味のない値になるとみなす値
     # "missing: Not collected" は "missing" と "not collected" が除去されて ": " になり、意味のないものと判定される
-    assert_equal true,  InsdcNullability.meaningless_value?('missing: Not collected')
-    assert_equal true,  InsdcNullability.meaningless_value?('missing:')
+    assert_equal true,  @nullability.meaningless_value?('missing: Not collected')
+    assert_equal true,  @nullability.meaningless_value?('missing:')
 
     # 意味のあるとみなされる値
-    assert_equal false, InsdcNullability.meaningless_value?('B1')
-    assert_equal false, InsdcNullability.meaningless_value?('B-1')
-    assert_equal false, InsdcNullability.meaningless_value?('missing: YP')
+    assert_equal false, @nullability.meaningless_value?('B1')
+    assert_equal false, @nullability.meaningless_value?('B-1')
+    assert_equal false, @nullability.meaningless_value?('missing: YP')
     # reporting_term を許容するように第二引数を true にする
-    assert_equal false, InsdcNullability.meaningless_value?('missing: control sample', true)
+    assert_equal false, @nullability.meaningless_value?('missing: control sample', true)
     # 空白は感知しない (他でチェック)
-    assert_equal false, InsdcNullability.null_not_recommended_value?('')
+    assert_equal false, @nullability.null_not_recommended_value?('')
   end
 end


### PR DESCRIPTION
## Summary

3 段階で thread safety と運用設定の現代化を進める。

### 1. validator のスレッドセーフ化 (`12eb3f0`)

- `InsdcNullability` を module + class accessor → class with constructor に。`@nullability = InsdcNullability.new(null_accepted:, null_not_recommended:)` を各 validator が持つ
- `DateFormat` も `DateFormat.set_config(@conf)` で class 変数に書き込んでいたのを `DateFormat.new(config_obj)` でインスタンス化。biosample_validator は `@date_format` をフィールドに持つ
- `TsvFieldValidator#invalid_value_for_null` の唯一の `InsdcNullability.null_value?` 呼び出しは local の `null_accepted_list` で inline 置換 (依存関係を切るため)
- 9 validators × 87 call sites を `@nullability.foo` に書き換え
- 上記により Puma worker が thread > 1 で走っても異種 validator 間の race condition は発生しない

### 2. Puma 設定を scaffold 寄せ (`ec081c1`)

- `threads ENV.fetch('RAILS_MAX_THREADS', 3)` (1 thread → 3 thread)
- `port ENV.fetch('PORT', 3000)` (DDBJ_VALIDATOR_APP_UNICORN_PORT 廃止)
- workers は `WEB_CONCURRENCY` で制御 (compose.yaml で 4 を明示)
- `preload_app!` は維持 (CoW メモリ共有)
- `MonitoringController` も自身を叩く際の port を `PORT` 経由に

### 3. Dockerfile を scaffold 寄せ (`df5c24a`)

- multi-stage (base/build/final)
- `ruby:4.0.3-slim` ベース
- jemalloc を LD_PRELOAD
- `BUNDLE_DEPLOYMENT=1` + bootsnap precompile
- `WORKDIR /usr/src/ddbj_validator` は維持 (compose の mount と log_analysis から参照されている)
- 非 root USER は scaffold default だが compose.yaml の `user: 0:0` と整合しないので付けない

## Test plan

- [x] `bin/rails zeitwerk:check` → All is good!
- [x] `bin/rails test` → 328 runs / 0 failures / 0 errors / 39 skips
- [x] `docker build .` → 成功 (431MB)
- [x] `docker run` smoke: Ruby 4.0.3 / Rails 8.1.3 起動確認
- [ ] staging デプロイ後、validation の golden path 確認 (1 worker × 3 threads / 4 workers × 3 threads など段階的にチューニング推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)