### PR TITLE
Fix Submitter#submission_id_list rescue return-leak bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ group :development do
 end
 
 group :test do
+  gem 'minitest-mock'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-mock (5.27.0)
     msgpack (1.8.0)
     net-ftp (0.3.9)
       net-protocol
@@ -297,6 +298,7 @@ DEPENDENCIES
   json
   json-schema
   mail
+  minitest-mock
   net-ftp
   nokogiri
   pg

--- a/lib/submitter/submitter.rb
+++ b/lib/submitter/submitter.rb
@@ -34,6 +34,7 @@ class Submitter
       trace = ex.backtrace.map {|row| row }.join("\n")
       @log.error(trace)
       ret[:status] = 'error'
+      ret
     end
   end
 

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'minitest/mock'
 
 class SubmissionsControllerTest < ActionDispatch::IntegrationTest
   test 'GET /api/submission/ids/:filetype without API_KEY returns 401' do
@@ -20,5 +21,20 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
   test 'GET /api/submission/:filetype/:id with wrong API_KEY returns 401' do
     get '/api/submission/biosample/SSUB000000', headers: {'API_KEY' => 'wrong'}
     assert_response :unauthorized
+  end
+
+  # 過去に submission_id_list の rescue 節が代入式 (`ret[:status] = 'error'`)
+  # で終わっていて、本来 ret hash を返すべきところを String 'error' を返していた。
+  # その結果 controller 側の `ret[:status]` が TypeError を投げ、本来の
+  # internal_server_error 応答に届かないまま落ちていた。
+  test 'GET /api/submission/ids/:filetype returns 500 when submitter raises' do
+    fake = Object.new
+    def fake.public_submission_id_list = raise(StandardError, 'boom')
+
+    BioSampleSubmitter.stub :new, fake do
+      get '/api/submission/ids/biosample', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :internal_server_error
   end
 end


### PR DESCRIPTION
## Summary

`lib/submitter/submitter.rb` の rescue 節が代入式 (`ret[:status] = 'error'`) で終わっていたため、本来 ret hash を返すべきところ String `'error'` を返していた。`SubmissionsController#ids` 側の `ret[:status]` 参照が `'error'[:status]` という呼び出しになり TypeError で 500 (default error page) を出して、本来の `head :internal_server_error` 応答に届かないまま落ちていた。

修正は rescue の最後に `ret` を 1 行追加するだけ。

## Test plan

- [x] regression test 追加: BioSampleSubmitter.new を stub して raise させた状態で endpoint を叩いて `:internal_server_error` を確認 (Minitest 6 から `minitest-mock` ががgemとして分離されたので追加)
- [x] `bin/rails test` → 329 runs / 0 failures / 0 errors / 39 skips
- [x] 修正前のコードに戻すと test が `TypeError: no implicit conversion of Symbol into Integer` を再現することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)