### PR TITLE
Drop test require 'validator/...' lines (Zeitwerk handles autoload)

### DIFF
--- a/test/lib/validator/analysis_validator_test.rb
+++ b/test/lib/validator/analysis_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/analysis_validator'
 
 class TestAnalysisValidator < Minitest::Test
   def setup

--- a/test/lib/validator/auto_annotator/auto_annotator_base_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_base_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/auto_annotator/auto_annotator_base'
 
 # auto_annotationのエラー情報で元ファイルから補正後のファイルが正しく出力できるか確認
 #

--- a/test/lib/validator/auto_annotator/auto_annotator_json_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_json_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/auto_annotator/auto_annotator_json'
 
 # auto_annotationのエラー情報で元ファイルから補正後のファイルが正しく出力できるか確認
 #

--- a/test/lib/validator/auto_annotator/auto_annotator_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/auto_annotator/auto_annotator'
 
 # auto_annotationのエラー情報で元ファイルから補正後のファイルが正しく出力できるか確認
 #

--- a/test/lib/validator/auto_annotator/auto_annotator_tsv_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_tsv_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'validator/common/file_parser'
-require 'validator/auto_annotator/auto_annotator_tsv'
 
 # auto_annotationのエラー情報で元ファイルから補正後のファイルが正しく出力できるか確認
 #

--- a/test/lib/validator/auto_annotator/auto_annotator_xml_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_xml_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'validator/auto_annotator/auto_annotator_xml'
-require 'validator/common/xml_convertor'
 
 # auto_annotationのエラー情報で元ファイルから補正後のファイルが正しく出力できるか確認
 #

--- a/test/lib/validator/bioproject_tsv_validator_test.rb
+++ b/test/lib/validator/bioproject_tsv_validator_test.rb
@@ -1,7 +1,4 @@
 require 'test_helper'
-require 'validator/bioproject_tsv_validator'
-require 'validator/common/insdc_nullability'
-require 'validator/common/organism_validator'
 
 class TestBioProjectTsvValidator < Minitest::Test
   def setup

--- a/test/lib/validator/bioproject_validator_test.rb
+++ b/test/lib/validator/bioproject_validator_test.rb
@@ -1,7 +1,4 @@
 require 'test_helper'
-require 'validator/bioproject_validator'
-require 'validator/common/insdc_nullability'
-require 'validator/common/organism_validator'
 
 class TestBioProjectValidator < Minitest::Test
   def setup

--- a/test/lib/validator/biosample_validator_test.rb
+++ b/test/lib/validator/biosample_validator_test.rb
@@ -1,8 +1,4 @@
 require 'test_helper'
-require 'validator/biosample_validator'
-require 'validator/common/coll_dump'
-require 'validator/common/insdc_nullability'
-require 'validator/common/xml_convertor'
 
 class TestBioSampleValidator < Minitest::Test
   def setup

--- a/test/lib/validator/combination_validator_test.rb
+++ b/test/lib/validator/combination_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/combination_validator'
 
 class TestCombinationValidator < Minitest::Test
   def setup

--- a/test/lib/validator/common/coll_dump_test.rb
+++ b/test/lib/validator/common/coll_dump_test.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'test_helper'
-require 'validator/common/coll_dump'
 
 class TestCollDump < Minitest::Test
   def test_parse

--- a/test/lib/validator/common/date_format_test.rb
+++ b/test/lib/validator/common/date_format_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/date_format'
 
 class TestDateFormat < Minitest::Test
   def setup

--- a/test/lib/validator/common/ddbj_db_validator_test.rb
+++ b/test/lib/validator/common/ddbj_db_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/ddbj_db_validator'
 
 class TestDDBJDbValidator < Minitest::Test
   def setup

--- a/test/lib/validator/common/excel2tsv_test.rb
+++ b/test/lib/validator/common/excel2tsv_test.rb
@@ -1,7 +1,5 @@
 require 'fileutils'
 require 'test_helper'
-require 'validator/common/insdc_nullability'
-require 'validator/common/excel2tsv'
 
 class TestExcel2Tsv < Minitest::Test
   def setup

--- a/test/lib/validator/common/geolocation_test.rb
+++ b/test/lib/validator/common/geolocation_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/geolocation'
 
 class TestGeolocation < Minitest::Test
   def test_format_insdc_latlon

--- a/test/lib/validator/common/insdc_nullability_test.rb
+++ b/test/lib/validator/common/insdc_nullability_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/insdc_nullability'
 
 class TestInsdcNullability < Minitest::Test
   def test_null_value?

--- a/test/lib/validator/common/ncbi_eutils_test.rb
+++ b/test/lib/validator/common/ncbi_eutils_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/ncbi_eutils'
 
 class TestNcbiEutils < Minitest::Test
   def test_exist_pubmed_id?

--- a/test/lib/validator/common/organism_validator_test.rb
+++ b/test/lib/validator/common/organism_validator_test.rb
@@ -1,7 +1,6 @@
 require 'yaml'
 require 'erb'
 require 'test_helper'
-require 'validator/common/organism_validator'
 
 class TestOrganismValidator < Minitest::Test
   def setup

--- a/test/lib/validator/common/save_auto_annotation_test.rb
+++ b/test/lib/validator/common/save_auto_annotation_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'validator/biosample_validator'
-require 'validator/common/xml_convertor'
 
 # auto_annotationの補正が効いているかの検証
 # auto_annotationが効いているかを確認するため、補正された上で別の検証メソッドでエラーとなる値を用意し、補正値が使用されているかを確認

--- a/test/lib/validator/common/tsv_column_validator_test.rb
+++ b/test/lib/validator/common/tsv_column_validator_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'validator/common/insdc_nullability'
-require 'validator/common/tsv_column_validator'
 
 class TestTsvColumnValidator < Minitest::Test
   def setup

--- a/test/lib/validator/common/tsv_field_validator_test.rb
+++ b/test/lib/validator/common/tsv_field_validator_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'validator/common/insdc_nullability'
-require 'validator/common/tsv_field_validator'
 
 class TestTsvFieldValidator < Minitest::Test
   def setup

--- a/test/lib/validator/common/validator_cache_test.rb
+++ b/test/lib/validator/common/validator_cache_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/biosample_validator'
 
 # BioSampleValidator の各 rule が Rails.cache 経由でキャッシュを効かせていることの確認。
 # test env のデフォルトは :null_store なので、ここだけ MemoryStore に差し替えて検証する。

--- a/test/lib/validator/common/xml_convetor_test.rb
+++ b/test/lib/validator/common/xml_convetor_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/common/xml_convertor'
 
 class TestXmlConvertor < Minitest::Test
   def setup

--- a/test/lib/validator/experiment_validator_test.rb
+++ b/test/lib/validator/experiment_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/experiment_validator'
 
 class TestExperimentValidator < Minitest::Test
   def setup

--- a/test/lib/validator/jvar_validator_test.rb
+++ b/test/lib/validator/jvar_validator_test.rb
@@ -1,7 +1,5 @@
 require 'fileutils'
 require 'test_helper'
-require 'validator/jvar_validator'
-require 'validator/common/insdc_nullability'
 
 class TestJVarValidator < Minitest::Test
   def setup

--- a/test/lib/validator/run_validator_test.rb
+++ b/test/lib/validator/run_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/run_validator'
 
 class TestRunValidator < Minitest::Test
   def setup

--- a/test/lib/validator/submission_validator_test.rb
+++ b/test/lib/validator/submission_validator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'validator/submission_validator'
 
 class TestSubmissionValidator < Minitest::Test
   def setup

--- a/test/lib/validator/trad_validator_test.rb
+++ b/test/lib/validator/trad_validator_test.rb
@@ -1,8 +1,6 @@
 require 'date'
 require 'fileutils'
 require 'test_helper'
-require 'validator/trad_validator'
-require 'validator/common/insdc_nullability'
 
 class TestTradValidator < Minitest::Test
   def setup

--- a/test/lib/validator/validator_test.rb
+++ b/test/lib/validator/validator_test.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'test_helper'
-require 'validator/validator'
 
 class TestValidator < Minitest::Test
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,6 @@ require 'rails/test_help'
 
 require 'webmock/minitest'
 
-# `require 'validator/foo'` でプロジェクトの lib/ 配下を参照できるよう LOAD_PATH に追加。
-$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
-
 # localhost (Virtuoso / Postgres) だけ許可して、それ以外の外部 HTTP は全て stub 経由に縛る。
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
## Summary

PR #190 上に積む clean up。lib/ が Zeitwerk autoload に乗ったので、test 側の `require 'validator/foo'` は不要 (定数参照で autoload が走る)。それに伴って `test_helper.rb` の `\$LOAD_PATH.unshift(...lib)` も撤去。

## Test plan

- [x] `bin/rails test` → 329 runs / 0 failures / 0 errors / 39 skips

## Note

Base branch は `validator-cache-to-rails-cache` (PR #190)。#190 マージ後に main に rebase されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)