### PR TITLE
DRA validators: convert remaining result-flag rule checks to early return

### DIFF
--- a/lib/validator/analysis_validator.rb
+++ b/lib/validator/analysis_validator.rb
@@ -114,21 +114,19 @@ class AnalysisValidator < ValidatorBase
   # true/false
   #
   def invalid_center_name (rule_code, analysis_label, analysis_node, submitter_id, line_num)
-    result = true
     acc_center_name = @db_validator.get_submitter_center_name(submitter_id)
-    analysis_node.xpath('@center_name').each do |center_node|
-      center_name = get_node_text(center_node, '.')
-      if acc_center_name != center_name
-        annotation = [
-          {key: 'Analysis name', value: analysis_label},
-          {key: 'center name', value: center_name},
-          {key: 'Path', value: '//ANALYSIS/@center_name'}
-        ]
-        add_error(rule_code, annotation)
-        result = false
-      end
+    mismatched = analysis_node.xpath('@center_name').map { get_node_text(it, '.') }.reject { it == acc_center_name }
+    return true if mismatched.empty?
+
+    mismatched.each do |center_name|
+      annotation = [
+        {key: 'Analysis name', value: analysis_label},
+        {key: 'center name',   value: center_name},
+        {key: 'Path',          value: '//ANALYSIS/@center_name'}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -187,23 +185,23 @@ class AnalysisValidator < ValidatorBase
   # true/false
   #
   def missing_analysis_filename (rule_code, analysis_label, analysis_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    analysis_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        if node_blank?(file_node, '@filename')
-          annotation = [
-            {key: 'Analysis name', value: analysis_label},
-            {key: 'filename', value: ''},
-            {key: 'Path', value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
-          ]
-          add_error(rule_code, annotation)
-          result = false
-        end
-      end
+    missing = analysis_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next unless node_blank?(file_node, '@filename')
+        [d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if missing.empty?
+
+    missing.each do |d_idx, f_idx|
+      annotation = [
+        {key: 'Analysis name', value: analysis_label},
+        {key: 'filename',      value: ''},
+        {key: 'Path',          value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@filename"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -217,26 +215,25 @@ class AnalysisValidator < ValidatorBase
   # true/false
   #
   def invalid_analysis_filename (rule_code, analysis_label, analysis_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    analysis_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        unless node_blank?(file_node, '@filename')
-          filename = get_node_text(file_node, '@filename')
-          unless filename =~ /^[A-Za-z0-9_.-]+$/
-            annotation = [
-              {key: 'Analysis name', value: analysis_label},
-              {key: 'filename', value: filename},
-              {key: 'Path', value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
-            ]
-            add_error(rule_code, annotation)
-            result = false
-          end
-        end
-      end
+    bad = analysis_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next if node_blank?(file_node, '@filename')
+        filename = get_node_text(file_node, '@filename')
+        next if filename =~ /^[A-Za-z0-9_.-]+$/
+        [filename, d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |filename, d_idx, f_idx|
+      annotation = [
+        {key: 'Analysis name', value: analysis_label},
+        {key: 'filename',      value: filename},
+        {key: 'Path',          value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@filename"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -250,25 +247,24 @@ class AnalysisValidator < ValidatorBase
   # true/false
   #
   def invalid_analysis_file_md5_checksum (rule_code, analysis_label, analysis_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    analysis_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        unless node_blank?(file_node, '@checksum')
-          checksum = get_node_text(file_node, '@checksum')
-          unless checksum =~ /^[A-Za-z0-9]{32}$/
-            annotation = [
-              {key: 'Analysis name', value: analysis_label},
-              {key: 'checksum', value: checksum},
-              {key: 'Path', value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@checksum"}
-            ]
-            add_error(rule_code, annotation)
-            result = false
-          end
-        end
-      end
+    bad = analysis_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next if node_blank?(file_node, '@checksum')
+        checksum = get_node_text(file_node, '@checksum')
+        next if checksum =~ /^[A-Za-z0-9]{32}$/
+        [checksum, d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |checksum, d_idx, f_idx|
+      annotation = [
+        {key: 'Analysis name', value: analysis_label},
+        {key: 'checksum',      value: checksum},
+        {key: 'Path',          value: "//ANALYSIS[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@checksum"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 end

--- a/lib/validator/combination_validator.rb
+++ b/lib/validator/combination_validator.rb
@@ -93,37 +93,22 @@ class CombinationValidator < ValidatorBase
   # true/false
   #
   def multiple_bioprojects_in_a_submission (rule_code, experiment_set, analysis_set)
-    result = true
-    ref_project_list = []
-    unless experiment_set.nil?
-      experiment_node = experiment_set.xpath('//EXPERIMENT')
-      experiment_node.each_with_index do |node, idx|
-        unless node_blank?(node, 'STUDY_REF/@accession')
-          ref_project_list.push(get_node_text(node, 'STUDY_REF/@accession'))
-        else # accession属性がない場合には空文字として扱い記述もれを検知する
-          ref_project_list.push('')
-        end
-      end
-    end
-    unless analysis_set.nil?
-      analysis_node = analysis_set.xpath('//ANALYSIS')
-      analysis_node.each_with_index do |node, idx|
-        unless node_blank?(node, 'STUDY_REF/@accession')
-          ref_project_list.push(get_node_text(node, 'STUDY_REF/@accession'))
-        else # accession属性がない場合には空文字として扱い記述もれを検知する
-          ref_project_list.push('')
-        end
-      end
-    end
-    if ref_project_list.uniq.size > 1
-      annotation = [
-        {key: 'STUDY_REF', value: ref_project_list.to_s},
-        {key: 'Path', value: '//EXPERIMENT/STUDY_REF/@accession, //ANALYSIS/STUDY_REF/@accession'}
-      ]
-      add_error(rule_code, annotation)
-      result = false
-    end
-    result
+    # accession 属性がない場合には空文字として扱い記述もれを検知する
+    collect_refs = ->(set, xpath) {
+      return [] if set.nil?
+      set.xpath(xpath).map {|node|
+        node_blank?(node, 'STUDY_REF/@accession') ? '' : get_node_text(node, 'STUDY_REF/@accession')
+      }
+    }
+    ref_project_list = collect_refs.call(experiment_set, '//EXPERIMENT') + collect_refs.call(analysis_set, '//ANALYSIS')
+    return true if ref_project_list.uniq.size <= 1
+
+    annotation = [
+      {key: 'STUDY_REF', value: ref_project_list.to_s},
+      {key: 'Path',      value: '//EXPERIMENT/STUDY_REF/@accession, //ANALYSIS/STUDY_REF/@accession'}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #
@@ -137,32 +122,27 @@ class CombinationValidator < ValidatorBase
   # true/false
   #
   def experiment_not_found (rule_code, experiment_set, run_set)
-    result = true
-    experiment_alias_list = [] # experiment id(alias)のリスト
-    experiment_set = experiment_set.xpath('//EXPERIMENT')
-    experiment_set.each_with_index do |experiment_node, idx|
-      unless node_blank?(experiment_node, '@alias')
-        experiment_alias_list.push(get_node_text(experiment_node, '@alias'))
-      end
+    experiment_alias_list = experiment_set.xpath('//EXPERIMENT').reject { node_blank?(it, '@alias') }
+                                          .map { get_node_text(it, '@alias') }
+    refname_path = 'EXPERIMENT_REF/@refname'
+
+    missing = run_set.xpath('//RUN').each_with_index.filter_map {|run_node, idx|
+      next if node_blank?(run_node, refname_path)
+      refname = get_node_text(run_node, refname_path)
+      next if experiment_alias_list.include?(refname)
+
+      [refname, idx + 1]
+    }
+    return true if missing.empty?
+
+    missing.each do |refname, run_idx|
+      annotation = [
+        {key: 'refname', value: refname},
+        {key: 'Path',    value: "//RUN[#{run_idx}]/#{refname_path}"}
+      ]
+      add_error(rule_code, annotation)
     end
-    run_set =  run_set.xpath('//RUN')
-    run_set.each_with_index do |run_node, idx|
-      idx += 1
-      refname_path = 'EXPERIMENT_REF/@refname'
-      unless node_blank?(run_node, refname_path)
-        refname = get_node_text(run_node, refname_path)
-        # 参照idがexperiment id(alias)のリストになければNG
-        if experiment_alias_list.find {|ex_alias| ex_alias == refname }.nil?
-          annotation = [
-            {key: 'refname', value: refname},
-            {key: 'Path', value: "//RUN[#{idx}]/#{refname_path}"}
-          ]
-          add_error(rule_code, annotation)
-          result = false
-        end
-      end
-    end
-    result
+    false
   end
 
   #
@@ -177,33 +157,33 @@ class CombinationValidator < ValidatorBase
   # true/false
   #
   def one_fastq_file_for_paired_library (rule_code, experiment_set, run_set)
-    result = true
-    run_set =  run_set.xpath('//RUN')
-    run_set.each_with_index do |run_node, idx|
-      idx += 1
-      refname_path = 'EXPERIMENT_REF/@refname'
-      unless node_blank?(run_node, refname_path)
-        refname = get_node_text(run_node, refname_path)
-        # 参照experimentを抽出
-        experiment_node = experiment_set.xpath("//EXPERIMENT[@alias='#{refname}']")
-        experiment_node.each do |ex_node|
-          # 参照experimentがpairedであり
-          unless ex_node.xpath('DESIGN/LIBRARY_DESCRIPTOR/LIBRARY_LAYOUT/PAIRED').empty?
-            # fastqまたはgeneric_fastqのファイルが1つしかなければNG
-            if run_node.xpath("DATA_BLOCK/FILES/FILE[@filetype='fastq']").size == 1 \
-             || run_node.xpath("DATA_BLOCK/FILES/FILE[@filetype='generic_fastq']").size == 1
-              annotation = [
-                {key: 'refname', value: refname},
-                {key: 'Path', value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
-              ]
-              add_error(rule_code, annotation)
-              result = false
-            end
-          end
-        end
-      end
+    refname_path = 'EXPERIMENT_REF/@refname'
+    bad = run_set.xpath('//RUN').each_with_index.filter_map {|run_node, idx|
+      next if node_blank?(run_node, refname_path)
+      refname = get_node_text(run_node, refname_path)
+
+      paired = experiment_set.xpath("//EXPERIMENT[@alias='#{refname}']").any? {
+        !it.xpath('DESIGN/LIBRARY_DESCRIPTOR/LIBRARY_LAYOUT/PAIRED').empty?
+      }
+      next unless paired
+
+      # fastq または generic_fastq のファイルが 1 つしかなければ NG
+      single_fastq = run_node.xpath("DATA_BLOCK/FILES/FILE[@filetype='fastq']").size == 1 ||
+                     run_node.xpath("DATA_BLOCK/FILES/FILE[@filetype='generic_fastq']").size == 1
+      next unless single_fastq
+
+      [refname, idx + 1]
+    }
+    return true if bad.empty?
+
+    bad.each do |refname, run_idx|
+      annotation = [
+        {key: 'refname', value: refname},
+        {key: 'Path',    value: "//RUN[#{run_idx}]/DATA_BLOCK/FILES/FILE"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -217,34 +197,30 @@ class CombinationValidator < ValidatorBase
   # true/false
   #
   def invalid_PacBio_RS_II_hdf_file_series (rule_code, experiment_set, run_set)
-    result = true
-    experiment_node = experiment_set.xpath('//EXPERIMENT[@alias]')
-    experiment_node.each do |ex_node|
-      if get_node_text(ex_node, 'PLATFORM/PACBIO_SMRT/INSTRUMENT_MODEL') == 'PacBio RS II'
-        refname = get_node_text(ex_node, '@alias')
-        run_set.xpath('//RUN').each_with_index do |run_node, idx|
-          # 参照しているrunであれば
-          unless run_node.xpath("EXPERIMENT_REF[@refname='#{refname}']").empty?
-            # filenameを配列に格納
-            filename_list = []
-            run_node.xpath('DATA_BLOCK/FILES/FILE').each do |file_node|
-              filename_list.push(get_node_text(file_node, '@filename'))
-            end
-            # filenameで*bax.h5が3ファイル, *bas.h5が1ファイルでないとNG
-            unless filename_list.select {|item| item =~ /bax.h5$/ }.size == 3 \
-             && filename_list.select {|item| item =~ /bas.h5$/ }.size == 1
-              annotation = [
-                {key: 'refname', value: refname},
-                {key: 'Path', value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
-              ]
-              add_error(rule_code, annotation)
-              result = false
-            end
-          end
-        end
-      end
+    pacbio_aliases = experiment_set.xpath('//EXPERIMENT[@alias]')
+                                   .select { get_node_text(it, 'PLATFORM/PACBIO_SMRT/INSTRUMENT_MODEL') == 'PacBio RS II' }
+                                   .map { get_node_text(it, '@alias') }
+
+    bad = run_set.xpath('//RUN').each_with_index.filter_map {|run_node, idx|
+      refname = pacbio_aliases.find { !run_node.xpath("EXPERIMENT_REF[@refname='#{it}']").empty? }
+      next unless refname
+
+      filenames = run_node.xpath('DATA_BLOCK/FILES/FILE').map { get_node_text(it, '@filename') }
+      # filename で *bax.h5 が 3 ファイル, *bas.h5 が 1 ファイルでないと NG
+      next if filenames.count { it =~ /bax.h5$/ } == 3 && filenames.count { it =~ /bas.h5$/ } == 1
+
+      [refname, idx]
+    }
+    return true if bad.empty?
+
+    bad.each do |refname, run_idx|
+      annotation = [
+        {key: 'refname', value: refname},
+        {key: 'Path',    value: "//RUN[#{run_idx}]/DATA_BLOCK/FILES/FILE"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -258,41 +234,38 @@ class CombinationValidator < ValidatorBase
   # true/false
   #
   def invalid_filetype (rule_code, experiment_set, run_set)
-    result = true
-    experiment_node = experiment_set.xpath('//EXPERIMENT[@alias]')
-    experiment_node.each do |ex_node|
-      platform_node = ex_node.xpath('PLATFORM/*[position() = 1]') # PLATFORMの最初の子要素を取得
-      if platform_node.any?
-        platform_name = platform_node[0].name # 子要素の要素名を取得し、confから該当するplatformの情報を抽出
-        platform_setting = @conf[:platform_filetype].select {|item| item['platform'] == platform_name }
-        if platform_setting.any? # confに記載されたplatform名であれば
-          accept_filetype_list = platform_setting[0]['filetype']
-          refname = get_node_text(ex_node, '@alias')
-          run_set.xpath('//RUN').each_with_index do |run_node, idx|
-            # 参照しているrunであれば
-            unless run_node.xpath("EXPERIMENT_REF[@refname='#{refname}']").empty?
-              # filetypeを配列に格納
-              filetype_list = []
-              run_node.xpath('DATA_BLOCK/FILES/FILE').each do |file_node|
-                filetype_list.push(get_node_text(file_node, '@filetype'))
-              end
-              # 記載されたfiletypeのリストから許容されたfiletypeを除き、他のfiletypeがあればNG
-              unaccept_filetype_list = filetype_list - accept_filetype_list
-              if unaccept_filetype_list.any?
-                annotation = [
-                  {key: 'refname', value: refname},
-                  {key: 'platform', value: platform_name},
-                  {key: 'filetype', value: unaccept_filetype_list.uniq.to_s},
-                  {key: 'Path', value: "//RUN[#{idx}]/DATA_BLOCK/FILES/FILE"}
-                ]
-                add_error(rule_code, annotation)
-                result = false
-              end
-            end
-          end
-        end
-      end
+    bad = experiment_set.xpath('//EXPERIMENT[@alias]').flat_map {|ex_node|
+      platform_name = ex_node.xpath('PLATFORM/*[position() = 1]').first&.name # PLATFORMの最初の子要素名
+      next [] if platform_name.nil?
+
+      platform_setting = @conf[:platform_filetype].find { it['platform'] == platform_name }
+      next [] if platform_setting.nil?
+
+      accept_filetype_list = platform_setting['filetype']
+      refname = get_node_text(ex_node, '@alias')
+
+      run_set.xpath('//RUN').each_with_index.filter_map {|run_node, idx|
+        next if run_node.xpath("EXPERIMENT_REF[@refname='#{refname}']").empty?
+
+        filetype_list = run_node.xpath('DATA_BLOCK/FILES/FILE').map { get_node_text(it, '@filetype') }
+        # 記載された filetype のリストから許容された filetype を除き、他があれば NG
+        unaccept = filetype_list - accept_filetype_list
+        next if unaccept.empty?
+
+        [refname, platform_name, unaccept.uniq, idx]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |refname, platform_name, unaccept, run_idx|
+      annotation = [
+        {key: 'refname',  value: refname},
+        {key: 'platform', value: platform_name},
+        {key: 'filetype', value: unaccept.to_s},
+        {key: 'Path',     value: "//RUN[#{run_idx}]/DATA_BLOCK/FILES/FILE"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 end

--- a/lib/validator/experiment_validator.rb
+++ b/lib/validator/experiment_validator.rb
@@ -114,21 +114,19 @@ class ExperimentValidator < ValidatorBase
   # true/false
   #
   def invalid_center_name (rule_code, experiment_label, experiment_node, submitter_id, line_num)
-    result = true
     acc_center_name = @db_validator.get_submitter_center_name(submitter_id)
-    experiment_node.xpath('@center_name').each do |center_node|
-      center_name = get_node_text(center_node, '.')
-      if acc_center_name != center_name
-        annotation = [
-          {key: 'Experiment name', value: experiment_label},
-          {key: 'center name', value: center_name},
-          {key: 'Path', value: '//EXPERIMENT/@center_name'}
-        ]
-        add_error(rule_code, annotation)
-        result = false
-      end
+    mismatched = experiment_node.xpath('@center_name').map { get_node_text(it, '.') }.reject { it == acc_center_name }
+    return true if mismatched.empty?
+
+    mismatched.each do |center_name|
+      annotation = [
+        {key: 'Experiment name', value: experiment_label},
+        {key: 'center name',     value: center_name},
+        {key: 'Path',            value: '//EXPERIMENT/@center_name'}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #

--- a/lib/validator/run_validator.rb
+++ b/lib/validator/run_validator.rb
@@ -114,21 +114,19 @@ class RunValidator < ValidatorBase
   # true/false
   #
   def invalid_center_name (rule_code, run_label, run_node, submitter_id, line_num)
-    result = true
     acc_center_name = @db_validator.get_submitter_center_name(submitter_id)
-    run_node.xpath('@center_name').each do |center_node|
-      center_name = get_node_text(center_node, '.')
-      if acc_center_name != center_name
-        annotation = [
-          {key: 'run name', value: run_label},
-          {key: 'center name', value: center_name},
-          {key: 'Path', value: '//RUN/@center_name'}
-        ]
-        add_error(rule_code, annotation)
-        result = false
-      end
+    mismatched = run_node.xpath('@center_name').map { get_node_text(it, '.') }.reject { it == acc_center_name }
+    return true if mismatched.empty?
+
+    mismatched.each do |center_name|
+      annotation = [
+        {key: 'run name',    value: run_label},
+        {key: 'center name', value: center_name},
+        {key: 'Path',        value: '//RUN/@center_name'}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -164,23 +162,23 @@ class RunValidator < ValidatorBase
   # true/false
   #
   def missing_run_filename (rule_code, run_label, run_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    run_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        if node_blank?(file_node, '@filename')
-          annotation = [
-            {key: 'Run name', value: run_label},
-            {key: 'filename', value: ''},
-            {key: 'Path', value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
-          ]
-          add_error(rule_code, annotation)
-          result = false
-        end
-      end
+    missing = run_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next unless node_blank?(file_node, '@filename')
+        [d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if missing.empty?
+
+    missing.each do |d_idx, f_idx|
+      annotation = [
+        {key: 'Run name', value: run_label},
+        {key: 'filename', value: ''},
+        {key: 'Path',     value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@filename"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -194,26 +192,25 @@ class RunValidator < ValidatorBase
   # true/false
   #
   def invalid_run_filename (rule_code, run_label, run_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    run_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        unless node_blank?(file_node, '@filename')
-          filename = get_node_text(file_node, '@filename')
-          unless filename =~ /^[A-Za-z0-9_.-]+$/
-            annotation = [
-              {key: 'Run name', value: run_label},
-              {key: 'filename', value: filename},
-              {key: 'Path', value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@filename"}
-            ]
-            add_error(rule_code, annotation)
-            result = false
-          end
-        end
-      end
+    bad = run_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next if node_blank?(file_node, '@filename')
+        filename = get_node_text(file_node, '@filename')
+        next if filename =~ /^[A-Za-z0-9_.-]+$/
+        [filename, d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |filename, d_idx, f_idx|
+      annotation = [
+        {key: 'Run name', value: run_label},
+        {key: 'filename', value: filename},
+        {key: 'Path',     value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@filename"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -227,26 +224,25 @@ class RunValidator < ValidatorBase
   # true/false
   #
   def invalid_run_file_md5_checksum (rule_code, run_label, run_node, line_num)
-    result = true
-    data_block_path = '//DATA_BLOCK'
-    run_node.xpath(data_block_path).each_with_index do |data_block_node, d_idx|
-      file_path = 'FILES/FILE'
-      data_block_node.xpath(file_path).each_with_index do |file_node, f_idx|
-        unless node_blank?(file_node, '@checksum')
-          checksum = get_node_text(file_node, '@checksum')
-          unless checksum =~ /^[A-Za-z0-9]{32}$/
-            annotation = [
-              {key: 'Run name', value: run_label},
-              {key: 'checksum', value: checksum},
-              {key: 'Path', value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx + 1}]/#{file_path}[#{f_idx + 1}]/@checksum"}
-            ]
-            add_error(rule_code, annotation)
-            result = false
-          end
-        end
-      end
+    bad = run_node.xpath('//DATA_BLOCK').each_with_index.flat_map {|data_block_node, d_idx|
+      data_block_node.xpath('FILES/FILE').each_with_index.filter_map {|file_node, f_idx|
+        next if node_blank?(file_node, '@checksum')
+        checksum = get_node_text(file_node, '@checksum')
+        next if checksum =~ /^[A-Za-z0-9]{32}$/
+        [checksum, d_idx + 1, f_idx + 1]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |checksum, d_idx, f_idx|
+      annotation = [
+        {key: 'Run name', value: run_label},
+        {key: 'checksum', value: checksum},
+        {key: 'Path',     value: "//RUN[#{line_num}]/DATA_BLOCK[#{d_idx}]/FILES/FILE[#{f_idx}]/@checksum"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #

--- a/lib/validator/submission_validator.rb
+++ b/lib/validator/submission_validator.rb
@@ -108,21 +108,19 @@ class SubmissionValidator < ValidatorBase
   # true/false
   #
   def invalid_center_name (rule_code, submission_label, submission_node, submitter_id, line_num)
-    result = true
     acc_center_name = @db_validator.get_submitter_center_name(submitter_id)
-    submission_node.xpath('@center_name').each do |center_node|
-      center_name = get_node_text(center_node, '.')
-      if acc_center_name != center_name
-        annotation = [
-          {key: 'Submission name', value: submission_label},
-          {key: 'center name', value: center_name},
-          {key: 'Path', value: '//SUBMISSION/@center_name'}
-        ]
-        add_error(rule_code, annotation)
-        result = false
-      end
+    mismatched = submission_node.xpath('@center_name').map { get_node_text(it, '.') }.reject { it == acc_center_name }
+    return true if mismatched.empty?
+
+    mismatched.each do |center_name|
+      annotation = [
+        {key: 'Submission name', value: submission_label},
+        {key: 'center name',     value: center_name},
+        {key: 'Path',            value: '//SUBMISSION/@center_name'}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -136,31 +134,26 @@ class SubmissionValidator < ValidatorBase
   # true/false
   #
   def invalid_hold_date (rule_code, submission_label, submission_node, line_num)
-    result = true
     data_path = '//SUBMISSION/ACTIONS/ACTION/HOLD/@HoldUntilDate'
-    submission_node.xpath(data_path).each_with_index do |data_node, idx| # 複数出現の可能性あり
-      unless node_blank?(data_node)
-        date_text = get_node_text(data_node)
-        begin
-          hold_until_date = DateTime.parse(date_text)
-          two_years_later = DateTime.now >> 24 # 24months
-          if hold_until_date > two_years_later
-            result = false
-          end
-        rescue ArgumentError # 日付に変換できない形式
-          result = false
-        end
-        # parseで処理しきれない場合
-        unless result
-          annotation = [
-            {key: 'Submission name', value: submission_label},
-            {key: 'HoldUntilDate', value: date_text},
-            {key: 'Path', value: "#{data_path}[#{idx + 1}]"} # 順番を表示
-          ]
-          add_error(rule_code, annotation)
-        end
-      end
+
+    bad = submission_node.xpath(data_path).each_with_index.filter_map {|data_node, idx| # 複数出現の可能性あり
+      next if node_blank?(data_node)
+      date_text = get_node_text(data_node)
+      date = Time.zone.parse(date_text) rescue nil
+      next if date && date <= 2.years.since
+
+      [date_text, idx + 1]
+    }
+    return true if bad.empty?
+
+    bad.each do |date_text, position|
+      annotation = [
+        {key: 'Submission name', value: submission_label},
+        {key: 'HoldUntilDate',   value: date_text},
+        {key: 'Path',            value: "#{data_path}[#{position}]"} # 順番を表示
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 end


### PR DESCRIPTION
## Summary

#192 の続き。analysis / run / submission / experiment / combination の rule check メソッドで残っていた

```ruby
result = true
xpath.each do |node|
  ...
  result = false if bad
end
result
```

形を early return + functional pipeline に揃えました。

### 対象 (16 メソッド)

- **analysis_validator**: `invalid_center_name`, `missing_analysis_filename`, `invalid_analysis_filename`, `invalid_analysis_file_md5_checksum`
- **run_validator**: `invalid_center_name`, `missing_run_filename`, `invalid_run_filename`, `invalid_run_file_md5_checksum`
- **submission_validator**: `invalid_center_name`, `invalid_hold_date`
- **experiment_validator**: `invalid_center_name`
- **combination_validator**: `multiple_bioprojects_in_a_submission`, `experiment_not_found`, `one_fastq_file_for_paired_library`, `invalid_PacBio_RS_II_hdf_file_series`, `invalid_filetype`

### パターン

- 単純な loop は `xpath(...).map.reject` 系で「失格項目だけ抽出 → 空なら return true → 列挙して add_error → false」に
- run/analysis の `DATA_BLOCK / FILES/FILE` の二重ループは `flat_map + filter_map` で `[..., d_idx, f_idx]` タプルを emit し、最後にまとめて error 出力
- combination 系は cross-reference (RUN ↔ EXPERIMENT) 形なので `find` で先に reference を確定 → `filter_map` でフィルタ

### 残

- `biosample_validator.rb` (11 件): `invalid_missing_value` のような 100 行超の複雑メソッドはあえて触れていない
- `bioproject_tsv_validator.rb` (18 件): 最も多いが似た形のレベル別チェック (mandatory/error/warning) で機械的に潰せそう
- `trad_validator.rb` (4 件), `bioproject_validator.rb` (4 件), metabobank 系 (2 件)

## Test plan

- [x] `bin/rails test` → 329 runs / 2170 assertions / 0 failures / 0 errors / 39 skips
- [ ] staging で validation の golden path 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)