### PR TITLE
Continue early-return refactor: bioproject / trad / metabobank validators

### DIFF
--- a/lib/validator/bioproject_validator.rb
+++ b/lib/validator/bioproject_validator.rb
@@ -164,34 +164,26 @@ class BioProjectValidator < ValidatorBase
   #
   def duplicated_project_title_and_description (rule_code, project_label, project_node, project_names_list, submission_id, line_num)
     return if project_names_list.nil?
-    result = true
+
     title_path = '//Project/ProjectDescr/Title'
-    desc_path = '//Project/ProjectDescr/Description'
+    desc_path  = '//Project/ProjectDescr/Description'
+    title       = project_node.xpath(title_path).empty? ? '' : get_node_text(project_node, title_path)
+    description = project_node.xpath(desc_path).empty?  ? '' : get_node_text(project_node, desc_path)
 
-    title = description = ''
-    if !project_node.xpath(title_path).empty? # 要素あり
-      title = get_node_text(project_node, title_path)
-    end
-    if !project_node.xpath(desc_path).empty? # 要素あり
-      description = get_node_text(project_node, desc_path)
-    end
+    duplicated = project_names_list.count { it[:bioproject_title] == title && it[:public_description] == description }
+    # submission_id がなければ DB から取得していないため、DB 内に 1 つでも同じ title&desc があると NG
+    # submission_id があれば DB から取得しており同一が 1 つ含まれる前提なので、2 つ以上で NG
+    threshold = submission_id.nil? ? 1 : 2
+    return true if duplicated < threshold
 
-    duplicated_submission = project_names_list.select {|item| item[:bioproject_title] == title && item[:public_description] == description }
-    # submission_idがなければDBから取得したデータではないため、DB内に一つでも同じtitle&descがあるとNG
-    result = false if submission_id.nil? && duplicated_submission.any?
-    # submission_idがあればDBから取得したデータであり、DB内に同一データが1つある。2つ以上あるとNG
-    result = false if !submission_id.nil? && duplicated_submission.size >= 2
-
-    if result == false
-      annotation = [
-        {key: 'Project name', value: project_label},
-        {key: 'Title', value: title},
-        {key: 'Description', value: description},
-        {key: 'Path', value: [title_path, desc_path]}
-      ]
-      add_error(rule_code, annotation)
-    end
-    result
+    annotation = [
+      {key: 'Project name', value: project_label},
+      {key: 'Title',        value: title},
+      {key: 'Description',  value: description},
+      {key: 'Path',         value: [title_path, desc_path]}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #
@@ -235,46 +227,40 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def invalid_publication_identifier (rule_code, project_label, project_node, line_num)
-    result = true
     pub_path = '//Project/ProjectDescr/Publication'
-    project_node.xpath(pub_path).each_with_index do |pub_node, idx| # 複数出現の可能性あり
-      valid = true
+    bad = project_node.xpath(pub_path).each_with_index.filter_map {|pub_node, idx| # 複数出現の可能性あり
+      id = get_node_text(pub_node, '@id')
       db_type = ''
-      id =  get_node_text(pub_node, '@id')
+      message = nil
       begin
         if !pub_node.xpath("DbType[text()='ePubmed']").empty? && !NcbiEutils.exist_pubmed_id?(id)
-          result = valid = false
           db_type = 'ePubmed'
         elsif !pub_node.xpath("DbType[text()='eDOI']").empty?
-          # DOIの場合はチェックをしない  https://github.com/ddbj/ddbj_validator/issues/18
-        elsif !pub_node.xpath("DbType[text()='ePMC']").empty?  && !NcbiEutils.exist_pmc_id?(id)
-          result = valid = false
+          # DOI の場合はチェックをしない https://github.com/ddbj/ddbj_validator/issues/18
+          next
+        elsif !pub_node.xpath("DbType[text()='ePMC']").empty? && !NcbiEutils.exist_pmc_id?(id)
           db_type = 'ePMC'
+        else
+          next
         end
-
-        if !valid
-          annotation = [
-            {key: 'Project name', value: project_label},
-            {key: 'DbType', value: db_type},
-            {key: 'ID', value: id},
-            {key: 'Path', value: "#{pub_path}[#{idx + 1}]/@id"} # 順番を表示
-          ]
-          add_error(rule_code, annotation)
-          result = false
-        end
-      rescue => ex # NCBI問合せ中のシステムエラーの場合はその旨メッセージを追加
-        annotation = [
-          {key: 'Project name', value: project_label},
-          {key: 'DbType', value: db_type},
-          {key: 'ID', value: id},
-          {key: 'Path', value: "#{pub_path}[#{idx + 1}]/@id"}, # 順番を表示
-          {key: 'Message', value: 'Validation processing failed because connection to NCBI service failed.'}
-        ]
-        add_error(rule_code, annotation)
-        result = false
+      rescue # NCBI 問合せ中のシステムエラー
+        message = 'Validation processing failed because connection to NCBI service failed.'
       end
+      [db_type, id, idx + 1, message]
+    }
+    return true if bad.empty?
+
+    bad.each do |db_type, id, position, message|
+      annotation = [
+        {key: 'Project name', value: project_label},
+        {key: 'DbType',       value: db_type},
+        {key: 'ID',           value: id},
+        {key: 'Path',         value: "#{pub_path}[#{position}]/@id"} # 順番を表示
+      ]
+      annotation.push({key: 'Message', value: message}) if message
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -288,27 +274,26 @@ class BioProjectValidator < ValidatorBase
   # true/false
   #
   def invalid_umbrella_project (rule_code, link_label, link_node, line_num)
-    result = true
-    hierar_path = "Link/Hierarchical[@type='TopAdmin']"
-    link_node.xpath(hierar_path).each_with_index do |hierar_node, idx_h|
-      member_path = 'MemberID/@accession'
-      hierar_node.xpath(member_path).each_with_index do |acs_attr_node, idx_m|
-        unless node_blank?(acs_attr_node)
-          bioproject_accession = get_node_text(acs_attr_node)
-          is_umbrella = @db_validator.umbrella_project?(bioproject_accession)
-          if !is_umbrella
-            annotation = [
-             {key: 'Project name', value: 'None'},
-             {key: 'BioProject accession', value: bioproject_accession},
-             {key: 'Path', value: "//Link/Hierarchical[#{idx_h + 1}]/#{member_path}[#{idx_m + 1}]"}
-            ]
-            add_error(rule_code, annotation)
-            result = false
-          end
-        end
-      end
+    member_path = 'MemberID/@accession'
+    bad = link_node.xpath("Link/Hierarchical[@type='TopAdmin']").each_with_index.flat_map {|hierar_node, idx_h|
+      hierar_node.xpath(member_path).each_with_index.filter_map {|acs_attr_node, idx_m|
+        next if node_blank?(acs_attr_node)
+        bioproject_accession = get_node_text(acs_attr_node)
+        next if @db_validator.umbrella_project?(bioproject_accession)
+        [bioproject_accession, idx_h + 1, idx_m + 1]
+      }
+    }
+    return true if bad.empty?
+
+    bad.each do |accession, idx_h, idx_m|
+      annotation = [
+        {key: 'Project name',         value: 'None'},
+        {key: 'BioProject accession', value: accession},
+        {key: 'Path',                 value: "//Link/Hierarchical[#{idx_h}]/#{member_path}[#{idx_m}]"}
+      ]
+      add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   #
@@ -327,22 +312,21 @@ class BioProjectValidator < ValidatorBase
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, project_label, taxonomy_id, organism_name, project_node, line_num)
     return nil if taxonomy_id.blank? || taxonomy_id == OrganismValidator::TAX_INVALID
-    result = true
+
     primary_taxid = project_node.xpath('//Project/ProjectType/ProjectTypeSubmission')
-    multispecies = project_node.xpath("//Project/ProjectType/ProjectTypeSubmission/Target[@sample_scope='eMultispecies']")
-    unless primary_taxid.empty? || !multispecies.empty? # Primary BioProjectではない場合と、eMultispeciesである場合はスキップ
-      result = @org_validator.is_infraspecific_rank(taxonomy_id)
-      if result == false
-        annotation = [
-          {key: 'Project name', value: project_label},
-          {key: 'Path', value: [@taxid_path, @orgname_path]},
-          {key: 'OrganismName', value: organism_name},
-          {key: 'taxID', value: taxonomy_id}
-        ]
-        add_error(rule_code, annotation)
-      end
-    end
-    result
+    multispecies  = project_node.xpath("//Project/ProjectType/ProjectTypeSubmission/Target[@sample_scope='eMultispecies']")
+    return true if primary_taxid.empty? || !multispecies.empty? # Primary BioProject ではない or eMultispecies はスキップ
+
+    return true if @org_validator.is_infraspecific_rank(taxonomy_id)
+
+    annotation = [
+      {key: 'Project name', value: project_label},
+      {key: 'Path',         value: [@taxid_path, @orgname_path]},
+      {key: 'OrganismName', value: organism_name},
+      {key: 'taxID',        value: taxonomy_id}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #

--- a/lib/validator/metabobank_idf_validator.rb
+++ b/lib/validator/metabobank_idf_validator.rb
@@ -89,27 +89,21 @@ class MetaboBankIdfValidator < ValidatorBase
   # true/false
   #
   def invalid_characters(rule_code, data)
-    result = true
     invalid_list = @tsv_validator.non_ascii_characters(data)
 
     # 除外項目だけ一旦チェック結果を削除して再度チェック？
-    invalid_list.delete_if {|invalid| invalid[:field_name] == 'Study Description' || invalid[:field_name] == 'Protocol Description' }
-    study_desc_value_list = @tsv_validator.field_value(data, 'Study Description')
-    protocol_desc_value_list = @tsv_validator.field_value(data, 'Protocol Description')
-    invalid_list.concat(invalid_char_on_desc('Study Description', study_desc_value_list))
-    invalid_list.concat(invalid_char_on_desc('Protocol Description', protocol_desc_value_list))
+    invalid_list.reject! { it[:field_name] == 'Study Description' || it[:field_name] == 'Protocol Description' }
+    invalid_list.concat(invalid_char_on_desc('Study Description',    @tsv_validator.field_value(data, 'Study Description')))
+    invalid_list.concat(invalid_char_on_desc('Protocol Description', @tsv_validator.field_value(data, 'Protocol Description')))
+    return true if invalid_list.empty?
 
-    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: 'Field name', value: invalid[:field_name]}]
-      if invalid[:value_idx].nil? # field_nameがNG
-      else  # field_valueがNG
-        annotation.push({key: 'Value', value: invalid[:value]})
-      end
+      annotation.push({key: 'Value', value: invalid[:value]}) unless invalid[:value_idx].nil? # field_value が NG の場合のみ value を出す
       annotation.push({key: 'Invalid Position', value: invalid[:disp_txt]})
       add_error(rule_code, annotation)
     end
-    result
+    false
   end
 
   # メタボバンク用の特殊文字を含んだチェック

--- a/lib/validator/metabobank_sdrf_validator.rb
+++ b/lib/validator/metabobank_sdrf_validator.rb
@@ -88,20 +88,18 @@ class MetaboBankSdrfValidator < ValidatorBase
   # true/false
   #
   def invalid_characters(rule_code, data)
-    result = true
     invalid_list = @tsv_validator.non_ascii_characters(data)
+    return true if invalid_list.empty?
 
-    result = false unless invalid_list.empty?
     invalid_list.each do |invalid|
       annotation = [{key: 'column name', value: invalid[:column_name]}]
-      if invalid[:row_idx].nil? # ヘッダーがNG
-      else # 値がNG
+      unless invalid[:row_idx].nil? # 値が NG の場合のみ row/value を出す
         annotation.push({key: 'Row number', value: @tsv_validator.offset_row_idx(invalid[:row_idx])})
-        annotation.push({key: 'Value', value: invalid[:value]})
+        annotation.push({key: 'Value',      value: invalid[:value]})
       end
       annotation.push({key: 'Invalid Position', value: invalid[:disp_txt]})
       add_error(rule_code, annotation)
     end
-    result
+    false
   end
 end

--- a/lib/validator/trad_validator.rb
+++ b/lib/validator/trad_validator.rb
@@ -535,58 +535,47 @@ class TradValidator < ValidatorBase
   # true/false
   #
   def missing_dblink(rule_code, dblink_list, anno_by_ent)
-    result = true
-    message = ''
+    has_required = ->(rows) {
+      qualifiers = rows.map { it[:qualifier] }
+      qualifiers.include?('project') && qualifiers.include?('biosample')
+    }
 
-    # COMMON entryにDBLINKがあるか
-    common_dblink_exist = false
-    common_dblink = dblink_list.select {|row| row[:entry] == 'COMMON' }
-    if common_dblink.any?
-      qual_list = common_dblink.map {|row| row[:qualifier] }
-      if qual_list.include?('project') && qual_list.include?('biosample')
-        common_dblink_exist = true
-      else
-        result = false
-        message = "COMMON entry requires both 'project' and 'biosample' for DBLINK."
-      end
-    end
+    # COMMON entry に DBLINK があるか、あった場合に project/biosample が揃っているか
+    common_dblink = dblink_list.select { it[:entry] == 'COMMON' }
+    common_dblink_exist = common_dblink.any? && has_required.call(common_dblink)
+    common_message = common_dblink.any? && !common_dblink_exist ? "COMMON entry requires both 'project' and 'biosample' for DBLINK." : nil
 
-    # 各entry(COMMON)に記載があるか、あった場合にproject/biosampleが揃っているか
-    missing_dblink_entry_list = []
+    # 各 entry (非 COMMON) に記載があるか、あった場合に project/biosample が揃っているか
+    entry_messages = []
+    missing_entries = []
     entry_dblink_count = 0
-    anno_by_ent.each do |entry_name, data|
+    anno_by_ent.each do |entry_name, _data|
       next if entry_name == 'COMMON'
-      entry_dblink = dblink_list.select {|row| row[:entry] == entry_name }
+      entry_dblink = dblink_list.select { it[:entry] == entry_name }
       if entry_dblink.any?
         entry_dblink_count += entry_dblink.size
-        qual_list = entry_dblink.map {|row| row[:qualifier] }
-        unless qual_list.include?('project') && qual_list.include?('biosample')
-          message += "#{entry_name} entry requires both 'project' and 'biosample' for DBLINK.."
-          missing_dblink_entry_list.push(entry_name)
-          result = false
+        unless has_required.call(entry_dblink)
+          entry_messages << "#{entry_name} entry requires both 'project' and 'biosample' for DBLINK.."
+          missing_entries << entry_name
         end
       elsif !common_dblink_exist
-        missing_dblink_entry_list.push(entry_name)
-        result = false
+        missing_entries << entry_name
       end
     end
 
-    # COMMONを除くentryにDBLINKに記載がなく、かつCOMMONにも記載がない
-    if entry_dblink_count == 0  && !common_dblink_exist
-      result = false
-    end
+    # COMMON を除く entry に DBLINK 記載がなく、かつ COMMON にも記載がない場合も NG
+    nothing_anywhere = entry_dblink_count.zero? && !common_dblink_exist
 
-    if result == false
-      entry_name = missing_dblink_entry_list.any? ? missing_dblink_entry_list.join(', ') : 'COMMON'
-      annotation = [
-        {key: 'entry', value: entry_name},
-        {key: 'File name', value: @anno_file}
-      ]
-      annotation.push({key: 'Message', value: message}) unless message == ''
-      add_error(rule_code, annotation)
-    end
+    return true if common_message.nil? && missing_entries.empty? && !nothing_anywhere
 
-    result
+    annotation = [
+      {key: 'entry',     value: missing_entries.any? ? missing_entries.join(', ') : 'COMMON'},
+      {key: 'File name', value: @anno_file}
+    ]
+    message = [common_message, *entry_messages].compact.join
+    annotation.push({key: 'Message', value: message}) unless message.empty?
+    add_error(rule_code, annotation)
+    false
   end
 
   #
@@ -602,35 +591,26 @@ class TradValidator < ValidatorBase
   def invalid_bioproject_accession(rule_code, bioproject_list)
     return nil if bioproject_list.nil? || bioproject_list.empty?
 
-    result = true
-    invalid_id_list = []
-    line_no_list = []
-    bioproject_list.each do |bioproject_line|
-      bioproject_accession = bioproject_line[:value]
-      if bioproject_accession =~ /^PRJD\w?\d{1,}$/
-        unless @db_validator.valid_bioproject_id?(bioproject_accession)
-          result = false
-          invalid_id_list.push(bioproject_accession)
-          line_no_list.push(bioproject_line[:line_no].to_s)
-        end
-      elsif bioproject_accession =~ /^PRJ(E|N)\w?\d{1,}$/
-        # 他極データは無視(TR_R0033でチェックする)
-      else # submission id(/^PSUB\d{6}$/)も認めない
-        result = false
-        invalid_id_list.push(bioproject_accession)
-        line_no_list.push(bioproject_line[:line_no].to_s)
+    invalid = bioproject_list.filter_map {|bioproject_line|
+      accession = bioproject_line[:value]
+      case accession
+      when /^PRJD\w?\d{1,}$/
+        next if @db_validator.valid_bioproject_id?(accession)
+      when /^PRJ(E|N)\w?\d{1,}$/
+        next # 他極データは無視 (TR_R0033 でチェック)
       end
-    end
+      # submission id (^PSUB\d{6}$) や上記でマッチしないものは NG
+      [accession, bioproject_line[:line_no].to_s]
+    }
+    return true if invalid.empty?
 
-    if result == false
-      annotation = [
-        {key: 'DBLINK/project', value: invalid_id_list.join(', ')},
-        {key: 'File name', value: @anno_file},
-        {key: 'Location', value: "Line: #{line_no_list.join(", ")}"}
-      ]
-      add_error(rule_code, annotation)
-    end
-    result
+    annotation = [
+      {key: 'DBLINK/project', value: invalid.map(&:first).join(', ')},
+      {key: 'File name',      value: @anno_file},
+      {key: 'Location',       value: "Line: #{invalid.map(&:last).join(', ')}"}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #
@@ -646,35 +626,26 @@ class TradValidator < ValidatorBase
   def invalid_biosample_accession(rule_code, biosample_list)
     return nil if biosample_list.nil? || biosample_list.empty?
 
-    result = true
-    invalid_id_list = []
-    line_no_list = []
-    biosample_list.each do |biosample_line|
-      biosample_accession = biosample_line[:value]
-      if biosample_accession =~ /^SAMD\w?\d{1,}$/
-        unless @db_validator.is_valid_biosample_id?(biosample_accession)
-          result = false
-          invalid_id_list.push(biosample_accession)
-          line_no_list.push(biosample_line[:line_no].to_s)
-        end
-      elsif biosample_accession =~ /^SAM(E|N)\w?\d{1,}$/
-        # 他極データは無視(TR_R0033でチェックする)
-      else # submission id(/^SSUB\d{6}$/)も認めない
-        result = false
-        invalid_id_list.push(biosample_accession)
-        line_no_list.push(biosample_line[:line_no].to_s)
+    invalid = biosample_list.filter_map {|biosample_line|
+      accession = biosample_line[:value]
+      case accession
+      when /^SAMD\w?\d{1,}$/
+        next if @db_validator.is_valid_biosample_id?(accession)
+      when /^SAM(E|N)\w?\d{1,}$/
+        next # 他極データは無視 (TR_R0033 でチェック)
       end
-    end
+      # submission id (^SSUB\d{6}$) や上記でマッチしないものは NG
+      [accession, biosample_line[:line_no].to_s]
+    }
+    return true if invalid.empty?
 
-    if result == false
-      annotation = [
-        {key: 'DBLINK/biosample', value: invalid_id_list.join(', ')},
-        {key: 'File name', value: @anno_file},
-        {key: 'Location', value: "Line: #{line_no_list.join(", ")}"}
-      ]
-      add_error(rule_code, annotation)
-    end
-    result
+    annotation = [
+      {key: 'DBLINK/biosample', value: invalid.map(&:first).join(', ')},
+      {key: 'File name',        value: @anno_file},
+      {key: 'Location',         value: "Line: #{invalid.map(&:last).join(', ')}"}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #
@@ -690,31 +661,21 @@ class TradValidator < ValidatorBase
   def invalid_drr_accession(rule_code, drr_list)
     return nil if drr_list.nil? || drr_list.empty?
 
-    result = true
-    invalid_id_list = []
-    line_no_list = []
-    # DRRは複数記載されるケースがあり、まとめてDBチェックする
-    drr_accession_id_list = drr_list.map {|row| row[:value] }
-    drr_accession_id_list.delete_if {|run_id| run_id =~ /^(S|E)RR\w?\d{1,}$/ } # 他極データは無視(TR_R0033でチェックする)
-    result_run_list = @db_validator.exist_check_run_ids(drr_accession_id_list)
-    result_run_list.each do |result_run_id|
-      if result_run_id[:is_exist] == false
-        invalid_id_list.push(result_run_id[:accession_id])
-        lines = drr_list.select {|row| row[:value] == result_run_id[:accession_id] }
-        line_no_list.concat(lines.map {|row| row[:line_no] })
-        result = false
-      end
-    end
+    # DRR は複数記載されるケースがあり、まとめて DB チェックする。
+    # 他極データ (S|ERR) は無視 (TR_R0033 でチェック)
+    drr_ids = drr_list.map { it[:value] }.reject { it =~ /^(S|E)RR\w?\d{1,}$/ }
+    not_exist = @db_validator.exist_check_run_ids(drr_ids).reject { it[:is_exist] }
+    return true if not_exist.empty?
 
-    if result == false
-      annotation = [
-        {key: 'DBLINK/sequence read archive', value: invalid_id_list.join(', ')},
-        {key: 'File name', value: @anno_file},
-        {key: 'Location', value: "Line: #{line_no_list.join(", ")}"}
-      ]
-      add_error(rule_code, annotation)
-    end
-    result
+    invalid_ids = not_exist.map { it[:accession_id] }
+    line_nos = invalid_ids.flat_map {|id| drr_list.select { it[:value] == id }.map { it[:line_no] } }
+    annotation = [
+      {key: 'DBLINK/sequence read archive', value: invalid_ids.join(', ')},
+      {key: 'File name',                    value: @anno_file},
+      {key: 'Location',                     value: "Line: #{line_nos.join(', ')}"}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #


### PR DESCRIPTION
## Summary

#193 の続き。bioproject / trad / metabobank の rule check メソッドで残っていた `result = true; ...; result` 形 11 メソッドを early-return + functional pipeline に揃えました。

### 対象

- **metabobank_idf_validator**: `invalid_characters`
- **metabobank_sdrf_validator**: `invalid_characters`
- **bioproject_validator**: `duplicated_project_title_and_description`, `invalid_publication_identifier`, `invalid_umbrella_project`, `taxonomy_at_species_or_infraspecific_rank`
- **trad_validator**: `missing_dblink`, `invalid_bioproject_accession`, `invalid_biosample_accession`, `invalid_drr_accession`

### 主な変化

- `case` で accession の prefix を分岐していた `if/elsif` 連鎖は `case/when ... next` パターンに
- `bioproject_validator#duplicated_project_title_and_description` の「submission_id 有無で許容重複数が変わる」ロジックを `threshold = submission_id.nil? ? 1 : 2` で表現
- `trad_validator#missing_dblink` は条件が複雑なので「収集 → 空判定 → 列挙してエラー」フローを明示。`has_required` を local lambda として共通化
- `invalid_publication_identifier` の rescue 経路でも annotation 生成は同じ流れに乗せる (Message を後付け)

### 残

- `biosample_validator.rb` (11 件): `invalid_missing_value` のような大型メソッド中心
- `bioproject_tsv_validator.rb` (18 件): mandatory/cv_check/format_check/selective_mandatory 等のレベル別チェックが似たパターンで並んでいる

## Test plan

- [x] `bin/rails test` → 329 runs / 2170 assertions / 0 failures / 0 errors / 39 skips
- [ ] staging で validation の golden path 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)