### PR TITLE
Stub @db_validator instead of skipping PG-dependent tests

### DIFF
--- a/test/lib/validator/analysis_validator_test.rb
+++ b/test/lib/validator/analysis_validator_test.rb
@@ -45,7 +45,7 @@ class TestAnalysisValidator < Minitest::Test
 
   # rule:DRA_R0004
   def test_invalid_center_name
-    skip_unless_pg_configured
+    stub_db_validator(@validator, get_submitter_center_name: ->(id) { id == 'test01' ? 'National Institute of Genetics' : nil })
     # ok case
     analysis_set = get_analysis_set_node("#{@test_file_dir}/4_invalid_center_name_analysis_ok.xml")
     ret = exec_validator('invalid_center_name', 'DRA_R0004', 'analysis name', analysis_set.first, 'test01', 1)

--- a/test/lib/validator/bioproject_tsv_validator_test.rb
+++ b/test/lib/validator/bioproject_tsv_validator_test.rb
@@ -99,7 +99,7 @@ class TestBioProjectTsvValidator < Minitest::Test
 
   # BP_R0016
   def test_invalid_umbrella_project
-    skip_unless_pg_configured
+    stub_db_validator(@validator, umbrella_project?: ->(accession) { %w[PRJDB1893 PSUB002342].include?(accession) })
     # ok case
     data = [{'key' => 'umbrella_bioproject_accession', 'values' => ['PRJDB1893']}] # accession_id
     ret = exec_validator('invalid_umbrella_project', 'BP_R0016', data)

--- a/test/lib/validator/bioproject_validator_test.rb
+++ b/test/lib/validator/bioproject_validator_test.rb
@@ -211,7 +211,8 @@ class TestBioProjectValidator < Minitest::Test
 
   # rule:BP_R0016
   def test_invalid_umbrella_project
-    skip_unless_pg_configured
+    # _ok fixture は PRJDB1554 / PSUB001851 を含むので両方 umbrella 扱い、_ng fixture の PRJDB3490 は非 umbrella
+    stub_db_validator(@validator, umbrella_project?: ->(accession) { %w[PRJDB1554 PSUB001851].include?(accession) })
     # ok case
     link_set = get_link_set_node("#{@test_file_dir}/16_invalid_umbrella_project_ok.xml")
     ret = exec_validator('invalid_umbrella_project', 'BP_R0016', 'Link', link_set.first, 1)

--- a/test/lib/validator/biosample_validator_test.rb
+++ b/test/lib/validator/biosample_validator_test.rb
@@ -6,7 +6,6 @@ class TestBioSampleValidator < Minitest::Test
     @validator = BioSampleValidator.new
     @xml_convertor = XmlConvertor.new
     @test_file_dir = File.expand_path('../../../data/biosample', __FILE__)
-    @ddbj_db_mode = ServiceAvailability::PG_CONFIGURED
     @package_version = Rails.configuration.validator['biosample']['package_version']
   end
 
@@ -745,7 +744,7 @@ class TestBioSampleValidator < Minitest::Test
   end
 
   def test_bioproject_submission_id_replacement
-    skip unless @ddbj_db_mode
+    stub_db_validator(@validator, get_bioproject_accession: ->(psub) { psub == 'PSUB004142' ? 'PRJDB3849' : nil })
 
     # ok case
     ## not psub_id
@@ -774,7 +773,8 @@ class TestBioSampleValidator < Minitest::Test
   end
 
   def test_invalid_bioproject_accession
-    skip unless @ddbj_db_mode
+    # PRJDB1 のみ DB に存在する
+    stub_db_validator(@validator, valid_bioproject_id?: ->(accession) { accession == 'PRJDB1' || accession == 'PSUB004142' })
 
     # ok case
     ## ncbi
@@ -1580,7 +1580,9 @@ jkl\"  "
   end
 
   def test_bioproject_not_found
-    skip unless @ddbj_db_mode
+    # PSUB004388 と PRJDB3595 は hirakawa が submitter として参照可能。それ以外 (PRJDB0000 等) は誰も参照不可
+    referenceable = {'PSUB004388' => ['hirakawa'], 'PRJDB3595' => ['hirakawa']}
+    stub_db_validator(@validator, get_bioproject_referenceable_submitter_ids: ->(accession) { referenceable.fetch(accession, []) })
 
     # ok case (given submitter_id matches DB response submitter_id)
     ## valid data
@@ -1667,7 +1669,8 @@ jkl\"  "
   end
 
   def test_invalid_bioproject_type
-    skip unless @ddbj_db_mode
+    # PSUB001851 / PRJDB1554 は umbrella project (NG)、それ以外 (PSUB004142 / PRJDB3490) は通常 project
+    stub_db_validator(@validator, umbrella_project?: ->(accession) { %w[PSUB001851 PRJDB1554].include?(accession) })
 
     # ok case
     # PSUB
@@ -1724,7 +1727,11 @@ jkl\"  "
   end
 
   def test_duplicated_locus_tag_prefix
-    skip unless @ddbj_db_mode
+    # DB 内の prefix 一覧: 'PP14' は SSUB005454 で使用、'RR1' は別 SSUB005462 で使用
+    stub_db_validator(@validator, get_all_locus_tag_prefix: [
+      {locus_tag_prefix: 'PP14', submission_id: 'SSUB005454'},
+      {locus_tag_prefix: 'RR1',  submission_id: 'SSUB005462'}
+    ])
 
     # ok case
     xml_data = File.read("#{@test_file_dir}/91_duplicated_locus_tag_prefix_SSUB005454_ok.xml")
@@ -2347,7 +2354,9 @@ jkl\"  "
   end
 
   def test_biosample_not_found
-    skip unless @ddbj_db_mode
+    # SAMD00032107-SAMD00032157 は hirotoju 配下で valid。SAMD00099999 は invalid
+    valid_range = (32107..32157).map { 'SAMD%08d' % it }
+    stub_db_validator(@validator, get_valid_sample_id_list: ->(ids, _submitter) { ids & valid_range })
 
     # ok case
     ret = exec_validator('biosample_not_found', 'BS_R0129', 'SampleA', 'SAMD00032107, SAMD00032108-SAMD00032156, SAMD00032157', 'hirotoju', 1)

--- a/test/lib/validator/experiment_validator_test.rb
+++ b/test/lib/validator/experiment_validator_test.rb
@@ -45,7 +45,7 @@ class TestExperimentValidator < Minitest::Test
 
   # rule:DRA_R0004
   def test_invalid_center_name
-    skip_unless_pg_configured
+    stub_db_validator(@validator, get_submitter_center_name: ->(id) { id == 'test01' ? 'National Institute of Genetics' : nil })
     # ok case
     experiment_set = get_experiment_set_node("#{@test_file_dir}/4_invalid_center_name_experiment_ok.xml")
     ret = exec_validator('invalid_center_name', 'DRA_R0004', 'experiment name', experiment_set.first, 'test01', 1)

--- a/test/lib/validator/run_validator_test.rb
+++ b/test/lib/validator/run_validator_test.rb
@@ -45,7 +45,7 @@ class TestRunValidator < Minitest::Test
 
   # rule:DRA_R0004
   def test_invalid_center_name
-    skip_unless_pg_configured
+    stub_db_validator(@validator, get_submitter_center_name: ->(id) { id == 'test01' ? 'National Institute of Genetics' : nil })
     # ok case
     run_set = get_run_set_node("#{@test_file_dir}/4_invalid_center_name_run_ok.xml")
     ret = exec_validator('invalid_center_name', 'DRA_R0004', 'run name', run_set.first, 'test01', 1)

--- a/test/lib/validator/submission_validator_test.rb
+++ b/test/lib/validator/submission_validator_test.rb
@@ -45,7 +45,7 @@ class TestSubmissionValidator < Minitest::Test
 
   # rule:DRA_R0004
   def test_invalid_center_name
-    skip_unless_pg_configured
+    stub_db_validator(@validator, get_submitter_center_name: ->(id) { id == 'test01' ? 'National Institute of Genetics' : nil })
     # ok case
     submission_set = get_submission_set_node("#{@test_file_dir}/4_invalid_center_name_submission_ok.xml")
     ret = exec_validator('invalid_center_name', 'DRA_R0004', 'submission name', submission_set.first, 'test01', 1)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,3 +74,23 @@ module ServiceAvailability
 end
 
 Minitest::Test.include(ServiceAvailability)
+
+# Validator の `@db_validator` を任意の値/Proc を返す fake で差し替える test helper。
+# 引数の Hash は method 名 → 戻り値 (Proc なら呼び出し時に引数を渡して返す)。
+#
+#   stub_db_validator(@validator,
+#     get_submitter_center_name: ->(id) { id == 'test01' ? 'NIG' : nil }
+#   )
+module DBValidatorStubs
+  def stub_db_validator(validator, **stubs)
+    fake = Object.new
+    stubs.each do |method, value|
+      fake.define_singleton_method(method) {|*args|
+        value.respond_to?(:call) ? value.call(*args) : value
+      }
+    end
+    validator.instance_variable_set(:@db_validator, fake)
+  end
+end
+
+Minitest::Test.include(DBValidatorStubs)


### PR DESCRIPTION
## Summary

39 件あった test skip のうち、`DDBJDbValidator` の特定メソッドだけ叩いていた 12 件は **stub で代替** すれば PG 不要で走るので、`skip_unless_pg_configured` / `skip unless @ddbj_db_mode` を撤去。

### 仕組み

`test_helper.rb` に `stub_db_validator(@validator, method: value_or_proc)` ヘルパを追加。validator の `@db_validator` を、指定メソッドに canned value を返す Object に差し替えるだけ。

```ruby
stub_db_validator(@validator, get_submitter_center_name: ->(id) { id == 'test01' ? 'NIG' : nil })
```

### 対象 (12 件)

- center_name 系 (4): `analysis` / `run` / `submission` / `experiment`
- umbrella project 系 (2): `bioproject` / `bioproject_tsv`
- biosample 系 (6): `bioproject_submission_id_replacement`, `invalid_bioproject_accession`, `bioproject_not_found`, `invalid_bioproject_type`, `duplicated_locus_tag_prefix`, `biosample_not_found`

skip 数が 39 → 27 に減少。

### 残スキップの内訳

- **`TestDDBJDbValidator` (22)**: SQL 自体が system under test。real PG が必要なので CI service container + seed で別途整備
- **`TestValidator` (3)**: full pipeline (`test_json`/`test_tsv`/`test_excel`)。DB call 箇所が多くここでは stub しきれない
- **`TestSaveAutoAnnotation#test_save_annotation_4`**: 既知バグで明示 skip (BS_R0096 auto-annotation)
- **`trad_validator_test` の `return nil if @ddbj_db_mode == false` 系 (15)**: Minitest の skip としてはカウントされていなかったが、PG 無しで silently no-op していたもの。本 PR では未対応 (follow-up で stub 化推奨)

## Test plan

- [x] `bin/rails test` → 329 runs / 2301 assertions / 0 failures / 0 errors / 27 skips (前 39 skips, 12 件解消, assertion 数も +131)
- [ ] staging deploy で挙動変化なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)