### PR TITLE
BS_R0096: emit scientific_name from tax_id in error annotation

### DIFF
--- a/lib/validator/biosample_validator.rb
+++ b/lib/validator/biosample_validator.rb
@@ -2294,17 +2294,21 @@ class BioSampleValidator < ValidatorBase
   # true/false
   #
   def taxonomy_at_species_or_infraspecific_rank (rule_code, sample_name, taxonomy_id, organism, line_num)
-    return nil if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
-    result = @org_validator.is_infraspecific_rank(taxonomy_id)
-    if result == false
-      annotation = [
-          {key: 'Sample name', value: sample_name},
-          {key: 'taxonomy_id', value: taxonomy_id},
-          {key: 'organism', value: organism}
-      ]
-      add_error(rule_code, annotation)
-    end
-    result
+    return nil  if InsdcNullability.null_value?(taxonomy_id) || taxonomy_id == OrganismValidator::TAX_INVALID
+    return true if @org_validator.is_infraspecific_rank(taxonomy_id)
+
+    # 入力 organism よりも tax_id に紐づく scientific_name を優先する。
+    # ユーザがミスタイプ ("eschericha coli" → tax_id 561) でも annotation は正しい属名 ("Escherichia") を示せる。
+    scientific_name = Rails.cache.fetch(['tax_match_organism', taxonomy_id]) {
+      @org_validator.get_organism_name(taxonomy_id)
+    }
+    annotation = [
+      {key: 'Sample name', value: sample_name},
+      {key: 'taxonomy_id', value: taxonomy_id},
+      {key: 'organism',    value: scientific_name || organism}
+    ]
+    add_error(rule_code, annotation)
+    false
   end
 
   #

--- a/test/lib/validator/common/save_auto_annotation_test.rb
+++ b/test/lib/validator/common/save_auto_annotation_test.rb
@@ -72,10 +72,9 @@ class TestSaveAutoAnnotation < Minitest::Test
 
   #
   # 4(taxonomy_error_warning)のauto annotationの保存が効いているかの検証
-  # 現状の validator は organism を "Escherchia coli" (入力のまま) として返すため期待値と不一致。
-  # 入力 tax_id にひもづく scientific_name を優先する意図と思われるが、実装が合っていない。要見直し
+  # 入力 organism がミスタイプ ("eschericha coli") でも、tax_id 561 に紐づく
+  # scientific_name "Escherichia" が annotation に出ることを確認する。
   def test_save_annotation_4
-    skip 'BS_R0096 auto-annotation prefers the fuzzy-matched tax (562) over the input tax (561); expected "Escherichia" not produced'
     biosample_set = @validator.validate("#{@test_file_dir}/save_auto_annotation_value_4.xml")
     error_list = @validator.instance_variable_get (:@error_list)
     error =  error_list.find {|error| error[:id] == 'BS_R0096' }


### PR DESCRIPTION
## Summary

`taxonomy_at_species_or_infraspecific_rank` (BS_R0096) はこれまで「caller が渡した input organism」をそのまま annotation に出していた。ユーザーが organism をタイポ ("eschericha coli") して有効な genus-level tax_id (561) と一緒に投げてきた場合、エラーメッセージにタイポがそのまま出てしまい、本ルールが指摘したい「tax_id 561 は genus rank なので species 以下の tax_id を入れて」という意図が伝わりにくい。

tax_id から `@org_validator.get_organism_name` で scientific_name を引いて annotation に出すように変更。lookup には既存の `tax_match_organism` Rails.cache key を再利用 (BS_R0004 と同じキャッシュ)。

`test_save_annotation_4` が skip されていたのはこの挙動の不一致が原因なので、修正に合わせて un-skip。

## Test plan

- [x] `bin/rails test` → 329 runs / 2442 assertions / 0 failures / 0 errors / 26 skips (前 27, `test_save_annotation_4` が走るようになって -1)
- [x] `bin/rails test test/lib/validator/common/save_auto_annotation_test.rb` → 6 runs / 7 assertions / 0 failures / 0 errors / 0 skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)