### PR TITLE
Make Postgres a hard test requirement, drop skip_unless_pg_configured

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,7 @@ jobs:
       # CI の runner からはコンテナに host ネットワーク経由でアクセスするため localhost を使う
       DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER: http://localhost:8890/sparql
 
-      # Postgres fixture (compose.test.yaml の postgres サービス)
-      DDBJ_VALIDATOR_APP_POSTGRES_HOST:    localhost
-      DDBJ_VALIDATOR_APP_POSTGRES_PORT:    '15432'
-      DDBJ_VALIDATOR_APP_POSTGRES_USER:    validator
-      DDBJ_VALIDATOR_APP_POSTGRES_PASSWD:  validator
-      DDBJ_VALIDATOR_APP_POSTGRES_TIMEOUT: '30'
+      # Postgres は config/validator.yml の test セクションに localhost:15432 を直書きしているので env 不要
 
     steps:
       - uses: actions/checkout@v6

--- a/config/validator.yml
+++ b/config/validator.yml
@@ -27,6 +27,14 @@ development: &dev
 
 test:
   <<: *dev
+  # compose.test.yaml の Postgres は 15432 にバインドする (dev の Postgres と
+  # ぶつからないように port をずらしてある)。test 実行時は常にこちらを向く
+  ddbj_rdb:
+    pg_host:    localhost
+    pg_port:    15432
+    pg_user:    validator
+    pg_pass:    validator
+    pg_timeout: 30
 
 staging:
   <<: *default

--- a/test/lib/validator/common/ddbj_db_validator_test.rb
+++ b/test/lib/validator/common/ddbj_db_validator_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class TestDDBJDbValidator < Minitest::Test
   def setup
-    skip_unless_pg_configured
     @db_validator = DDBJDbValidator.new(Rails.configuration.validator['ddbj_rdb'])
   end
 

--- a/test/lib/validator/validator_test.rb
+++ b/test/lib/validator/validator_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 class TestValidator < Minitest::Test
   def setup
     skip_unless_virtuoso_available
-    skip_unless_pg_configured
     @validator = Validator.new
     @tmp_file_dir = File.expand_path('../../../data/tmp', __FILE__)
     @bs_test_file_dir = File.expand_path('../../../data/biosample', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,8 +49,9 @@ Minitest::Test.include(DefaultHttpStubs)
 #     end
 #   end
 module ServiceAvailability
-  PG_CONFIGURED = ENV.key?('DDBJ_VALIDATOR_APP_POSTGRES_HOST')
-
+  # PostgreSQL は必須前提とする。起動していなければ tests がそのまま fail する
+  # (compose.test.yaml で立ち上げてから走らせる)。Virtuoso は起動コストが大きいので
+  # CI 以外では skip を許容する。
   VIRTUOSO_REACHABLE = begin
     endpoint = ENV['DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER'] || 'http://localhost:8890/sparql'
     uri      = URI.parse(endpoint)
@@ -62,10 +63,6 @@ module ServiceAvailability
     res.code.start_with?('2')
   rescue StandardError
     false
-  end
-
-  def skip_unless_pg_configured
-    skip 'PostgreSQL not configured (set DDBJ_VALIDATOR_APP_POSTGRES_HOST to enable)' unless PG_CONFIGURED
   end
 
   def skip_unless_virtuoso_available


### PR DESCRIPTION
## Summary

`compose.test.yaml` で立ち上がる Postgres と fixture (schema + seed) は既に揃っていて、CI の `Tests` ワークフローもそれを起動してから `bin/rails test` を走らせている。それなのに `skip_unless_pg_configured` で skip フォールバックを残していたので、ローカルで PG を起こし忘れた状態でも tests が "通ってしまう" のが安全側じゃなかった。

PG が起動していないなら **tests を素直に fail** させるように:

- `skip_unless_pg_configured` ヘルパと `PG_REACHABLE` (今 PR 中で追加していたもの) を撤去
- `TestDDBJDbValidator` / `TestValidator` から skip 呼び出しを撤去
- `config/validator.yml` の test セクションで `ddbj_rdb` を `localhost:15432` に固定 (compose.test.yaml と一致)
- これに伴って CI workflow の `DDBJ_VALIDATOR_APP_POSTGRES_*` 5 個の env を撤去 (YAML が直接持つので)

## Test plan

- [x] `docker compose -f compose.test.yaml up -d && bin/rails test` → 329 runs / 2579 assertions / 0 failures / 0 errors / **0 skips** (前 26 skips → 全廃)
- [x] PG を落として `bin/rails test` → TestDDBJDbValidator / TestValidator が `PG::ConnectionBad` で fail することを確認

## 残スキップ

`Virtuoso` 側の `skip_unless_virtuoso_available` は引き続き skip 容認。Virtuoso は起動コストが大きいので CI 以外では skip を許容する方針 (今回の対象外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)