### PR TITLE
Make Virtuoso a hard test requirement, drop skip_unless_virtuoso_available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,6 @@ jobs:
   rake-test:
     runs-on: ubuntu-latest
 
-    env:
-      # conf/validator.yml のデフォルトはコンテナ内の "http://virtuoso:8890/sparql" だが、
-      # CI の runner からはコンテナに host ネットワーク経由でアクセスするため localhost を使う
-      DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER: http://localhost:8890/sparql
-
-      # Postgres は config/validator.yml の test セクションに localhost:15432 を直書きしているので env 不要
-
     steps:
       - uses: actions/checkout@v6
         with:

--- a/config/validator.yml
+++ b/config/validator.yml
@@ -27,8 +27,10 @@ development: &dev
 
 test:
   <<: *dev
-  # compose.test.yaml の Postgres は 15432 にバインドする (dev の Postgres と
-  # ぶつからないように port をずらしてある)。test 実行時は常にこちらを向く
+  # compose.test.yaml で立ち上がる Virtuoso / Postgres を必ず指す。
+  # Postgres は dev と port が衝突しないよう 15432 にずらしてある。
+  sparql_endpoint:
+    master_endpoint: http://localhost:8890/sparql
   ddbj_rdb:
     pg_host:    localhost
     pg_port:    15432

--- a/test/lib/validator/bioproject_tsv_validator_test.rb
+++ b/test/lib/validator/bioproject_tsv_validator_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class TestBioProjectTsvValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = BioProjectTsvValidator.new
     @test_file_dir = File.expand_path('../../../data/bioproject', __FILE__)
   end

--- a/test/lib/validator/bioproject_validator_test.rb
+++ b/test/lib/validator/bioproject_validator_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class TestBioProjectValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = BioProjectValidator.new
     @test_file_dir = File.expand_path('../../../data/bioproject', __FILE__)
   end

--- a/test/lib/validator/biosample_validator_test.rb
+++ b/test/lib/validator/biosample_validator_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class TestBioSampleValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = BioSampleValidator.new
     @xml_convertor = XmlConvertor.new
     @test_file_dir = File.expand_path('../../../data/biosample', __FILE__)

--- a/test/lib/validator/common/organism_validator_test.rb
+++ b/test/lib/validator/common/organism_validator_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 class TestOrganismValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     setting = Rails.configuration.validator
     @validator = OrganismValidator.new(setting['sparql_endpoint']['master_endpoint'], setting['named_graph_uri']['taxonomy'])
   end

--- a/test/lib/validator/common/save_auto_annotation_test.rb
+++ b/test/lib/validator/common/save_auto_annotation_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 #
 class TestSaveAutoAnnotation < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = BioSampleValidator.new
     @xml_convertor = XmlConvertor.new
     @test_file_dir = File.expand_path('../../../../data/biosample', __FILE__)

--- a/test/lib/validator/common/validator_cache_test.rb
+++ b/test/lib/validator/common/validator_cache_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 # test env のデフォルトは :null_store なので、ここだけ MemoryStore に差し替えて検証する。
 class TestValidatorCache < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @original_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new
     @validator = BioSampleValidator.new

--- a/test/lib/validator/trad_validator_test.rb
+++ b/test/lib/validator/trad_validator_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 class TestTradValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = TradValidator.new
     @test_file_dir = File.expand_path('../../../data/trad', __FILE__)
 

--- a/test/lib/validator/validator_test.rb
+++ b/test/lib/validator/validator_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 
 class TestValidator < Minitest::Test
   def setup
-    skip_unless_virtuoso_available
     @validator = Validator.new
     @tmp_file_dir = File.expand_path('../../../data/tmp', __FILE__)
     @bs_test_file_dir = File.expand_path('../../../data/biosample', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,37 +41,6 @@ end
 
 Minitest::Test.include(DefaultHttpStubs)
 
-# 外部サービス (PostgreSQL / Virtuoso) が使えない環境 (CI 等) でテストをスキップするヘルパ。
-#
-#   class TestFoo < Minitest::Test
-#     def setup
-#       skip_unless_virtuoso_available
-#     end
-#   end
-module ServiceAvailability
-  # PostgreSQL は必須前提とする。起動していなければ tests がそのまま fail する
-  # (compose.test.yaml で立ち上げてから走らせる)。Virtuoso は起動コストが大きいので
-  # CI 以外では skip を許容する。
-  VIRTUOSO_REACHABLE = begin
-    endpoint = ENV['DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER'] || 'http://localhost:8890/sparql'
-    uri      = URI.parse(endpoint)
-
-    res = Net::HTTP.start(uri.host, uri.port, open_timeout: 2, read_timeout: 2) {|http|
-      http.request(Net::HTTP::Get.new("#{uri.path}?query=ASK%20%7B%7D&format=application%2Fjson"))
-    }
-
-    res.code.start_with?('2')
-  rescue StandardError
-    false
-  end
-
-  def skip_unless_virtuoso_available
-    skip 'Virtuoso SPARQL endpoint not reachable' unless VIRTUOSO_REACHABLE
-  end
-end
-
-Minitest::Test.include(ServiceAvailability)
-
 # Validator の `@db_validator` を任意の値/Proc を返す fake で差し替える test helper。
 # 引数の Hash は method 名 → 戻り値 (Proc なら呼び出し時に引数を渡して返す)。
 #


### PR DESCRIPTION
## Summary

PR #200 で Postgres を hard requirement にしたのと同じ理由で Virtuoso も skip 撤去。compose.test.yaml で立てる前提なら skip は隠蔽でしかない。

- `test_helper.rb` から `VIRTUOSO_REACHABLE` 定数と `skip_unless_virtuoso_available` ヘルパを削除
- 8 つの test ファイルから `skip_unless_virtuoso_available` 呼び出しを削除
- `config/validator.yml` の test section に `sparql_endpoint.master_endpoint: http://localhost:8890/sparql` を直書き
- これに伴って CI workflow の `DDBJ_VALIDATOR_APP_VIRTUOSO_ENDPOINT_MASTER` env も redundant なので削除

## Test plan

- [x] `docker compose -f compose.test.yaml up -d && bin/rails test` → 329 / 2579 / 0 / 0 / 0
- [ ] CI で Virtuoso fixture が正しく load されているか確認 (workflow の `LOAD /fixtures/load.sql` step は維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)