### PR TITLE
Instrument SubmissionsController auth to detect API_KEY usage

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -33,7 +33,19 @@ class SubmissionsController < ApplicationController
   # request.headers['API_KEY'] は underscore を含むキーを HTTP_ プレフィックス変換
   # しないため env を直接参照する。旧 Sinatra 版の headers["HTTP_API_KEY"] と互換。
   def authenticate_curator
-    return if request.env['HTTP_API_KEY'] == 'curator'
+    if request.env['HTTP_API_KEY'] == 'curator'
+      # 外部クライアントが本当にこの認証を使っているか観測するための instrument。
+      # MonitoringController が同一コンテナの自身を叩く経路は 127.0.0.1 / ::1 になるので除外。
+      # Sentry の event を見て 1〜2 ヶ月ヒットがなければ authenticate_curator 自体を撤去予定。
+      unless request.remote_ip.in?(%w[127.0.0.1 ::1])
+        Sentry.capture_message('SubmissionsController authenticated', level: :info, extra: {
+          path:       request.path,
+          remote_ip:  request.remote_ip,
+          user_agent: request.user_agent
+        })
+      end
+      return
+    end
 
     send_file Rails.public_path.join('api/error_unauthorized.json'),
               type: 'application/json', disposition: 'inline', status: :unauthorized


### PR DESCRIPTION
## Summary

`API_KEY=curator` 認証が実際に外部クライアントから叩かれているか確認するための instrument。

`SubmissionsController#authenticate_curator` が成功した時に Sentry event を発行する。`MonitoringController` の自己叩きは `127.0.0.1`/`::1` になるので除外、純粋に「外部から API_KEY=curator が来た」ケースだけ拾う。

調査結果 (前回会話):
- d-way (utoron)、ddbj-repository、submission-bulk(-st26)、submission-mss、cloakman、service-gateway-conf を grep しても呼び出し痕跡なし
- production の `validator.log` は Logger.new ベースの validator-internal log で HTTP 層は記録されない
- Nginx access log は service-gateway 側にあるはずだがアクセス権なし

→ 1〜2 ヶ月観察してヒット 0 なら `authenticate_curator` ごと撤去予定。

記録項目:
- `path`: 叩かれたエンドポイント
- `remote_ip`: 呼び出し元 IP
- `user_agent`: クライアント識別

## Test plan

- [x] `bin/rails test` → 329 / 2579 / 0 / 0 / 0
- [ ] staging deploy → MonitoringController の自己 probe では Sentry event が発火しないことを確認
- [ ] production deploy → 一定期間観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)