### PR TITLE
Drop redundant RUBY_YJIT_ENABLE from compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,6 @@ services:
       - ${DDBJ_VALIDATOR_APP_PORT:-18840}:3000
     environment:
       TZ: Asia/Tokyo
-      RUBY_YJIT_ENABLE: "true"
       RAILS_ENV: ${RAILS_ENV}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       WEB_CONCURRENCY: 4


### PR DESCRIPTION
## Summary

Rails 7.2+ は `Rails::Application` 起動時に Ruby が YJIT 対応していれば自動で有効化するので、`compose.yaml` の `RUBY_YJIT_ENABLE: "true"` は redundant。

## Test plan

- [ ] staging deploy 後、起動ログで YJIT が enable になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)