### PR TITLE
Fix three small bugs (DEFAULT_PACKAGE_VERSION, analysisx, submision)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::API
   end
 
   def biosample_package_version
-    BioSampleValidator::DEFAULT_PACKAGE_VERSION
+    Rails.configuration.validator['biosample']['package_version']
   end
 
   def data_dir

--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -15,7 +15,10 @@ class ValidationsController < ApplicationController
 
     validation_params = {params: {'file_format' => {}}}
 
-    %w[all_db biosample bioproject submission experiment run analysisx jvar trad_anno trad_seq trad_agp metabobank_idf metabobank_sdrf].each do |category|
+    # analysis は 2021-01-17 (d1566c0 "accept jvar excel input") に typo 化 ('analysisx') して
+    # 入口を塞いだ状態が続いている。lib/validator/analysis_validator.rb 自体は残っているので
+    # 再開するときはここに 'analysis' を足す。
+    %w[all_db biosample bioproject submission experiment run jvar trad_anno trad_seq trad_agp metabobank_idf metabobank_sdrf].each do |category|
       next unless params[category]
 
       validation_params[category.to_sym]                  = save_uploaded_file(save_dir, category)

--- a/lib/validator/validator.rb
+++ b/lib/validator/validator.rb
@@ -54,7 +54,7 @@ class Validator
 
         params.each do |k, v|
           case k.to_s
-          when 'biosample', 'bioproject', 'submision', 'experiment', 'run', 'analysis', 'jvar', 'trad_anno', 'trad_seq', 'trad_agp', 'metabobank_idf', 'metabobank_sdrf', 'output'
+          when 'biosample', 'bioproject', 'submission', 'experiment', 'run', 'analysis', 'jvar', 'trad_anno', 'trad_seq', 'trad_agp', 'metabobank_idf', 'metabobank_sdrf', 'output'
             params[k] = File.expand_path(v)
             # TODO check file exist and permission, need write permission to output file
             if k.to_s == 'output'


### PR DESCRIPTION
## Summary

3 つの小バグを修正:

### 1. `ApplicationController#biosample_package_version` の `NameError`

`BioSampleValidator::DEFAULT_PACKAGE_VERSION` を参照しているが、定数は #184 で削除済。`/api/package_list` (または `attribute_list` / `package_info` / `list_with_groups`) を `?version=...` 指定なしで叩くと `NameError` で 500 になる。

→ `Rails.configuration.validator['biosample']['package_version']` (= validator 内部 `@package_version` と同じ source of truth) を読むように変更。

### 2. `ValidationsController#create` の `'analysisx'` を撤去

2021-01-17 の `d1566c0` "accept jvar excel input" コミットで意図的に `analysis` → `analysisx` と typo を仕込んで category 一覧から外していた。typo 経由の disable は意図が伝わらないので、

- リストから `analysisx` ごと削除
- 「`analysis` 経路は意図的に塞いである、再開時はここに足す」コメントを追加

`lib/validator/analysis_validator.rb` 自体は残っているので、再開時はリストに `'analysis'` を追加するだけで OK。

### 3. `Validator.parse_param!` の `'submision'` typo

`case k.to_s` の when 句に `'submision'` (s 抜け)。CLI から `--submission` で投入された XML が File.expand_path / readability check を通らない経路に。`'submission'` に修正。

## Test plan

- [x] `bin/rails test` → 329 / 2579 / 0 / 0 / 0
- [ ] staging で `/api/package_list` を `?version` なしで叩いて 200 が返ることを確認 (修正前は 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)