### PR TITLE
Pass Accept header value as a plain string

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::API
   end
 
   def accept_header
-    request.env.select {|k, _| k.start_with?('HTTP_ACCEPT') }.presence || []
+    request.headers['Accept'].to_s
   end
 
   def render_error (message, status:)

--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -127,7 +127,7 @@ class ValidationsController < ApplicationController
   # jvar の結果は元ファイルが Excel だが変換された JSON を返すケースもあるので、
   # Accept ヘッダで xlsx / json を切り替える。
   def send_jvar_file (file_list)
-    if accept_header.to_s.include?('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    if accept_header.include?('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
       file = file_list.find {|f| f.end_with?('.xlsx') }
       type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     else

--- a/lib/package/package.rb
+++ b/lib/package/package.rb
@@ -181,13 +181,8 @@ class Package < SPARQLBase
       end
 
       # accept header から希望ファイル形式を決める
-      unless accept_header.nil? || accept_header['HTTP_ACCEPT'].nil?
-        accept_header_list = accept_header['HTTP_ACCEPT'].split(',').map {|item| item.chomp.strip }
-      end
-      return_file_format = 'excel' # default format
-      if accept_header_list.include?('text/tab-separated-values')
-        return_file_format = 'tsv'
-      end
+      accept_header_list = accept_header.to_s.split(',').map(&:strip)
+      return_file_format = accept_header_list.include?('text/tab-separated-values') ? 'tsv' : 'excel'
       template_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../public/template')
       puts template_file_dir
       file_path = ''

--- a/lib/validator/auto_annotator/auto_annotator.rb
+++ b/lib/validator/auto_annotator/auto_annotator.rb
@@ -14,16 +14,13 @@ class AutoAnnotator
   # @param org_file 元ファイル(Validateしたファイル)
   # @param result_file Validator結果のJSON
   # @param annotated_file_path出力ファイルパス
-  # @accept_header Accept headerのリスト.ユーザ希望の出力形式  e.g.{"HTTP_ACCEPT"=>"text/html,text/tab-separated-values"}
+  # @accept_header Accept ヘッダ値. ユーザ希望の出力形式 e.g. "text/html,text/tab-separated-values"
   # @return result  {status: "succeed", file: annotated_file_path} or {status: "error", message: message}
   def create_annotated_file(org_file, result_file, annotated_file_path, filetype, accept_header)
     info = {orginal_file: org_file.to_s, output_file: annotated_file_path}
     @log.info("execute auto_annotation: #{info}")
     begin
-      accept_header_list = []
-      unless accept_header.nil? || accept_header['HTTP_ACCEPT'].nil?
-        accept_header_list = accept_header['HTTP_ACCEPT'].split(',').map {|item| item.chomp.strip }
-      end
+      accept_header_list = accept_header.to_s.split(',').map(&:strip)
       input_file_format = ''
       return_file_format = ''
       if filetype == 'biosample'

--- a/test/lib/validator/auto_annotator/auto_annotator_test.rb
+++ b/test/lib/validator/auto_annotator/auto_annotator_test.rb
@@ -10,7 +10,7 @@ class TestAutoAnnotator < Minitest::Test
   def test_create_annotated_file
     # OK case biosample
     # biosample (input:xml, output: any)
-    http_accept = {'HTTP_ACCEPT'=>'*/*'}
+    http_accept = '*/*'
     input_file = "#{@test_file_dir}/biosample_test_warning.xml"
     validator_result_file = "#{@test_file_dir}/biosample_test_warning_xml_result.json"
     output_file = "#{@test_file_dir}/biosample_test_warning_annotated.xml"
@@ -21,7 +21,7 @@ class TestAutoAnnotator < Minitest::Test
 
     # OK case bioproject
     ## bioproject(input:tsv, output:tsv)
-    http_accept = {'HTTP_ACCEPT'=>'*/*, text/tab-separated-values'}
+    http_accept = '*/*, text/tab-separated-values'
     input_file = "#{@test_file_dir}/bioproject_test_warning.tsv"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_tsv_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated.tsv"
@@ -31,7 +31,7 @@ class TestAutoAnnotator < Minitest::Test
     assert_equal 'tsv', ret[:file_type]
 
     ## bioproject(input:json, output:json)
-    http_accept = {'HTTP_ACCEPT'=>'application/json'}
+    http_accept = 'application/json'
     input_file = "#{@test_file_dir}/bioproject_test_warning.tsv"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_tsv_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated_from_tsv.tsv"
@@ -41,7 +41,7 @@ class TestAutoAnnotator < Minitest::Test
     assert_equal 'json', ret[:file_type]
 
     ## bioproject(input:tsv, output:json)
-    http_accept = {'HTTP_ACCEPT'=>'*/*'} # default format is json
+    http_accept = '*/*' # default format is json
     input_file = "#{@test_file_dir}/bioproject_test_warning.json"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_json_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated.json"
@@ -51,7 +51,7 @@ class TestAutoAnnotator < Minitest::Test
     assert_equal 'json', ret[:file_type]
 
     ## bioproject(input:json, output:tsv)
-    http_accept = {'HTTP_ACCEPT'=>'*/*, text/tab-separated-values'}
+    http_accept = '*/*, text/tab-separated-values'
     input_file = "#{@test_file_dir}/bioproject_test_warning.json"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_json_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated_from_json.json"
@@ -63,7 +63,7 @@ class TestAutoAnnotator < Minitest::Test
 
     # NG case biosample
     ## biosample not exist original xml file
-    http_accept = {'HTTP_ACCEPT'=>'*/*'}
+    http_accept = '*/*'
     input_file = "#{@test_file_dir}/biosample_test_warning_not_exist.xml"
     validator_result_file = "#{@test_file_dir}/biosample_test_warning_xml_result.json"
     output_file = "#{@test_file_dir}/biosample_test_warning_annotated.xml"
@@ -74,7 +74,7 @@ class TestAutoAnnotator < Minitest::Test
     assert ret[:message].include?("Can't parse")
 
     ## biosample invalid original file format (xml => json)
-    http_accept = {'HTTP_ACCEPT'=>'*/*'}
+    http_accept = '*/*'
     input_file = "#{@test_file_dir}/bioproject_test_warning.json"
     validator_result_file = "#{@test_file_dir}/biosample_test_warning_xml_result.json"
     output_file = "#{@test_file_dir}/biosample_test_warning_annotated.xml"
@@ -83,7 +83,7 @@ class TestAutoAnnotator < Minitest::Test
     assert ret[:message].include?('Failed to output annotated file')
 
     ## biosample not exist validator result json file
-    http_accept = {'HTTP_ACCEPT'=>'*/*'}
+    http_accept = '*/*'
     input_file = "#{@test_file_dir}/biosample_test_warning.xml"
     validator_result_file = "#{@test_file_dir}/biosample_test_warning_xml_result_not_exist.json"
     output_file = "#{@test_file_dir}/biosample_test_warning_annotated.xml"
@@ -92,7 +92,7 @@ class TestAutoAnnotator < Minitest::Test
     assert ret[:message].include?('Validation result file is not found.')
 
     ## biosample 'broken' validator result json file
-    http_accept = {'HTTP_ACCEPT'=>'*/*'}
+    http_accept = '*/*'
     input_file = "#{@test_file_dir}/biosample_test_warning.xml"
     validator_result_file = "#{@test_file_dir}/biosample_test_warning_xml_result_broken.json"
     output_file = "#{@test_file_dir}/biosample_test_warning_annotated.xml"
@@ -103,7 +103,7 @@ class TestAutoAnnotator < Minitest::Test
 
     # NG case bioproject
     ## bioproject not exist original tsv file
-    http_accept = {'HTTP_ACCEPT'=>'*/*, text/tab-separated-values'}
+    http_accept = '*/*, text/tab-separated-values'
     input_file = "#{@test_file_dir}/bioproject_test_warning_not_exist.tsv"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_tsv_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated.tsv"
@@ -112,7 +112,7 @@ class TestAutoAnnotator < Minitest::Test
     assert ret[:message]
 
     ## bioproject 'broken' original json file
-    http_accept = {'HTTP_ACCEPT'=>'application/json'}
+    http_accept = 'application/json'
     input_file = "#{@test_file_dir}/bioproject_test_warning_broken.json"
     validator_result_file = "#{@test_file_dir}/bioproject_test_warning_json_result.json"
     output_file = "#{@test_file_dir}/bioproject_test_warning_annotated.json"


### PR DESCRIPTION
## Summary

`ApplicationController#accept_header` は `request.env.select { it.start_with?('HTTP_ACCEPT') }` で `HTTP_ACCEPT` / `HTTP_ACCEPT_LANGUAGE` / `HTTP_ACCEPT_ENCODING` 全部を hash で返していたが、consumer (`AutoAnnotator` / `Package`) は `hash['HTTP_ACCEPT']` だけ読んで同じパースをしていた。`validations_controller#send_jvar_file` の `accept_header.to_s.include?(...)` は Ruby の Hash#to_s フォーマット (`"{\"HTTP_ACCEPT\"=>\"...\"}"`) に依存していて少々怪しい。

整理:

- helper を `request.headers['Accept'].to_s` (string) を返すように変更
- `AutoAnnotator#create_annotated_file` / `Package#attribute_template_file` の引数は string を直接受け取り、`.split(',').map(&:strip)` で list に
- `validations_controller#send_jvar_file` も `.to_s` 不要 (string なので)
- test fixtures 14 箇所 (`{'HTTP_ACCEPT' => '*/*'}` 等) も plain string に bulk replace

## Test plan

- [x] `bin/rails test` → 329 / 2579 / 0 / 0 / 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)