### PR TITLE
Scope CORS to /api/*

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -2,7 +2,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
 
-    resource '*',
+    resource '/api/*',
       headers: :any,
       methods: %i[get post put patch delete options head]
   end


### PR DESCRIPTION
## Summary

`resource '*'` → `resource '/api/*'`。`origins '*'` は内部サービスで Nginx 側 IP allowlist に守られているので維持、CORS 適用対象だけ API パスに限定。`/up` (Rails health check) や ActionDispatch::Static 経由の静的ファイル (`public/api/error_*.json` 等) は CORS preflight 不要。

## Test plan

- [x] `bin/rails test` → 329 / 2579 / 0 / 0 / 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)