### PR TITLE
Return 404 for missing validations

### DIFF
--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -50,27 +50,23 @@ class ValidationsController < ApplicationController
     status_file_path = File.join(save_dir, 'status.json')
     output_file_path = File.join(save_dir, 'result.json')
 
-    if File.exist?(output_file_path) && File.exist?(status_file_path)
-      result = JSON.parse(File.read(output_file_path))
+    status_json = JSON.parse(File.read(status_file_path))
+    result      = JSON.parse(File.read(output_file_path)) if File.exist?(output_file_path)
 
-      if result['status'] == 'error'
-        head :internal_server_error
+    if result.nil?
+      if status_json['status'] == 'running'
+        render_error('Validation process has not finished yet', status: :bad_request)
       else
-        status_json = JSON.parse(File.read(status_file_path))
-        result      = Validator.new.grouped_message(result) if params.key?('grouped_messages')
-
-        render json: status_json.merge('result' => result)
+        render_error('Validation not found', status: :not_found)
       end
+    elsif result['status'] == 'error'
+      head :internal_server_error
     else
-      message =
-        if File.exist?(status_file_path) && JSON.parse(File.read(status_file_path))['status'] == 'running'
-          'Validation process has not finished yet'
-        else
-          'Invalid uuid'
-        end
-
-      render_error(message, status: :bad_request)
+      result = Validator.new.grouped_message(result) if params.key?('grouped_messages')
+      render json: status_json.merge('result' => result)
     end
+  rescue Errno::ENOENT
+    render_error('Validation not found', status: :not_found)
   end
 
   def status
@@ -79,7 +75,7 @@ class ValidationsController < ApplicationController
     if File.exist?(status_file_path)
       send_file status_file_path, type: 'application/json', disposition: 'inline'
     else
-      render_error('Invalid uuid', status: :bad_request)
+      render_error('Validation not found', status: :not_found)
     end
   end
 
@@ -92,7 +88,7 @@ class ValidationsController < ApplicationController
     elsif file_list.size == 1
       send_file file_list.first, filename: File.basename(file_list.first), type: 'application/xml'
     else
-      render_error('Invalid uuid or filetype', status: :bad_request)
+      render_error('Validation file not found', status: :not_found)
     end
   end
 
@@ -102,7 +98,7 @@ class ValidationsController < ApplicationController
     org_file_list = Dir.glob(File.join(save_dir, params[:filetype], '*'))
 
     unless File.exist?(result_file) && org_file_list.size == 1
-      render_error('Invalid uuid or filetype, or the auto-correct data is not exist of the uuid specified', status: :bad_request)
+      render_error('Auto-correct data not found for the given uuid / filetype', status: :not_found)
       return
     end
 

--- a/test/controllers/validations_controller_test.rb
+++ b/test/controllers/validations_controller_test.rb
@@ -1,27 +1,27 @@
 require 'test_helper'
 
 class ValidationsControllerTest < ActionDispatch::IntegrationTest
-  test 'GET /api/validation/:uuid with unknown uuid returns 400 Invalid uuid' do
+  test 'GET /api/validation/:uuid with unknown uuid returns 404 Validation not found' do
     get '/api/validation/00000000-0000-0000-0000-000000000000'
-    assert_response :bad_request
-    assert_equal 'Invalid uuid', JSON.parse(response.body)['message']
+    assert_response :not_found
+    assert_equal 'Validation not found', JSON.parse(response.body)['message']
   end
 
-  test 'GET /api/validation/:uuid/status with unknown uuid returns 400 Invalid uuid' do
+  test 'GET /api/validation/:uuid/status with unknown uuid returns 404 Validation not found' do
     get '/api/validation/00000000-0000-0000-0000-000000000000/status'
-    assert_response :bad_request
-    assert_equal 'Invalid uuid', JSON.parse(response.body)['message']
+    assert_response :not_found
+    assert_equal 'Validation not found', JSON.parse(response.body)['message']
   end
 
-  test 'GET /api/validation/:uuid/:filetype with unknown uuid returns 400' do
+  test 'GET /api/validation/:uuid/:filetype with unknown uuid returns 404' do
     get '/api/validation/00000000-0000-0000-0000-000000000000/biosample'
-    assert_response :bad_request
-    assert_equal 'Invalid uuid or filetype', JSON.parse(response.body)['message']
+    assert_response :not_found
+    assert_equal 'Validation file not found', JSON.parse(response.body)['message']
   end
 
-  test 'GET /api/validation/:uuid/:filetype/autocorrect with unknown uuid returns 400' do
+  test 'GET /api/validation/:uuid/:filetype/autocorrect with unknown uuid returns 404' do
     get '/api/validation/00000000-0000-0000-0000-000000000000/biosample/autocorrect'
-    assert_response :bad_request
-    assert_match 'Invalid uuid or filetype', JSON.parse(response.body)['message']
+    assert_response :not_found
+    assert_match 'Auto-correct data not found', JSON.parse(response.body)['message']
   end
 end


### PR DESCRIPTION
## Summary

- `validations#show` / `status` / `file` / `autocorrect` now return **404 Not Found** instead of 400 Bad Request when the UUID (or filetype) does not resolve to stored data.
- Refactor `show` to read `status.json` once and rescue `Errno::ENOENT`, replacing the fragile `File.exist?(...) && JSON.parse(File.read(...))` guard.
- Update controller tests accordingly.

## Why

The route already enforces `uuid: /[0-9a-f-]+/`, so malformed UUIDs already produce 404 from the router. Valid-format-but-missing UUIDs were still returning 400 with messages like `Invalid uuid`, which is inconsistent and semantically wrong (the request is well-formed; the resource simply doesn't exist).

This is an internal service behind an IP allowlist, so the small client-compatibility risk is acceptable — happy to revisit if anything complains.

## Test plan

- [x] `bin/rails test test/controllers/validations_controller_test.rb` (4 runs, 9 assertions, 0 failures)
- [x] `bin/rails test` full suite (329 runs, 2579 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)