### PR TITLE
Atomic writes for status.json / result.json

### DIFF
--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -51,15 +51,19 @@ class ValidationsController < ApplicationController
     output_file_path = File.join(save_dir, 'result.json')
 
     status_json = JSON.parse(File.read(status_file_path))
-    result      = JSON.parse(File.read(output_file_path)) if File.exist?(output_file_path)
 
-    if result.nil?
+    begin
+      result = JSON.parse(File.read(output_file_path))
+    rescue Errno::ENOENT
       if status_json['status'] == 'running'
         render_error('Validation process has not finished yet', status: :bad_request)
       else
         render_error('Validation not found', status: :not_found)
       end
-    elsif result['status'] == 'error'
+      return
+    end
+
+    if result['status'] == 'error'
       head :internal_server_error
     else
       result = Validator.new.grouped_message(result) if params.key?('grouped_messages')
@@ -211,7 +215,11 @@ class ValidationsController < ApplicationController
     nil
   end
 
+  # status.json は web リクエストと validator スレッドが同時に読み書きするため、
+  # 部分書き込みを掴ませないよう temp + rename でアトミックに置き換える。
   def write_status_file (path, payload)
-    File.write(path, JSON.generate(payload))
+    tmp = "#{path}.#{Process.pid}.#{SecureRandom.hex(4)}.tmp"
+    File.write(tmp, JSON.generate(payload))
+    File.rename(tmp, path)
   end
 end

--- a/lib/validator/validator.rb
+++ b/lib/validator/validator.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'logger'
+require 'securerandom'
 require 'yaml'
 require 'fileutils'
 
@@ -128,9 +129,7 @@ class Validator
         ret = {status: 'error', message: ex.message}
       end
 
-      File.open(params[:output], 'w') do |file|
-        file.puts(JSON.generate(ret))
-      end
+      atomic_write(params[:output], JSON.generate(ret))
       FileUtils.rm(running_file)
       JSON.generate(ret)
     end
@@ -205,9 +204,7 @@ class Validator
         ret['stats'] = stats
         ret['messages'] = split_result[:error_list]
         @log.info('validation result: ' + 'fail')
-        File.open(params[:output], 'w') do |file|
-          file.puts(JSON.generate(ret))
-        end
+        atomic_write(params[:output], JSON.generate(ret))
       else # 正常に変換できた場合は、Excelに含まれていたfiletypeと出力TSVのファイルパスを返す
         result = split_result[:filetypes]
       end
@@ -362,6 +359,14 @@ class Validator
         body     "#{body_text}"
       end
       mail.deliver!
+    end
+
+    # result.json は web リクエストとこのスレッドが同時に読み書きするため、
+    # 部分書き込みを掴ませないよう temp + rename でアトミックに置き換える。
+    def atomic_write(path, content)
+      tmp = "#{path}.#{Process.pid}.#{SecureRandom.hex(4)}.tmp"
+      File.write(tmp, content)
+      File.rename(tmp, path)
     end
 
     private_class_method :create_command_parser


### PR DESCRIPTION
## Summary

- `validations_controller#write_status_file` and `Validator#execute` / `#split_excel_sheet` now write JSON via temp + `File.rename`, so concurrent readers can never see a truncated file.
- `validations#show` reads `result.json` directly and rescues `Errno::ENOENT` instead of `File.exist? && File.read`, matching the status.json read above.

## Why

Both `status.json` and `result.json` are written by the validator thread while web requests read them in parallel. `File.write` / `File.open(..., 'w')` are not atomic — open → write → close — so a reader catching the file mid-write would see truncated content and `JSON::ParserError` would surface as a 500. `File.rename` on the same filesystem is atomic, so a reader sees either the old or the new file, never a partial one.

The `show` change closes the last `File.exist?` + `File.read` TOCTOU window I introduced in #209.

## Test plan

- [x] `bin/rails test` (329 runs, 2579 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)