### PR TITLE
Cover the version-fallback path in PackagesControllerTest

### DIFF
--- a/test/controllers/packages_controller_test.rb
+++ b/test/controllers/packages_controller_test.rb
@@ -1,6 +1,24 @@
 require 'test_helper'
 
 class PackagesControllerTest < ActionDispatch::IntegrationTest
+  test 'GET /api/package_list without version falls back to configured biosample version' do
+    get '/api/package_list'
+    assert_response :success
+    assert_kind_of Array, JSON.parse(response.body)
+  end
+
+  test 'GET /api/package_and_group_list without version falls back to configured biosample version' do
+    get '/api/package_and_group_list'
+    assert_response :success
+    assert_kind_of Array, JSON.parse(response.body)
+  end
+
+  test 'GET /api/attribute_list with package but no version falls back to configured biosample version' do
+    get '/api/attribute_list', params: {package: 'MIGS.vi.soil'}
+    assert_response :success
+    assert_kind_of Array, JSON.parse(response.body)
+  end
+
   test 'GET /api/attribute_list without package param returns 400' do
     get '/api/attribute_list'
     assert_response :bad_request


### PR DESCRIPTION
## Summary

Add three integration tests that exercise the `requested_version` → `biosample_package_version` fallback path, which was previously untested:

- `GET /api/package_list` (no params)
- `GET /api/package_and_group_list` (no params)
- `GET /api/attribute_list?package=MIGS.vi.soil` (no version)

## Why

The existing tests only hit the `before_action :ensure_package_param` early-return on `attributes` / `attribute_template` / `info`, so `requested_version` was never evaluated and the `BioSampleValidator::DEFAULT_PACKAGE_VERSION` NameError fixed in ddad9f0 went undetected. Worse, `#list` and `#list_with_groups` had **no controller tests at all**, even though they always go through the fallback when called without a version.

## Verification

Reverted `application_controller.rb` to its pre-ddad9f0 state and ran `bin/rails test test/controllers/packages_controller_test.rb`:

```
3 errors, 0 skips
NameError: uninitialized constant BioSampleValidator::DEFAULT_PACKAGE_VERSION
    app/controllers/application_controller.rb:9 ...
```

Against current main: 6 runs, 12 assertions, 0 failures.

Tests rely on the test Virtuoso (compose.test.yaml) having the BioSample 1.5.0 package data — same data the rest of the suite already queries (e.g. `biosample_validator_test.rb` calls `get_attributes_of_package('MIGS.vi.soil', ...)`).

## Test plan

- [x] `bin/rails test` (332 runs, 2585 assertions, 0 failures, 0 errors, 0 skips)
- [x] Regression check against ddad9f0~1 produces the original NameError

🤖 Generated with [Claude Code](https://claude.com/claude-code)