### PR TITLE
Cover the success / 400 / 500 paths in SubmissionsControllerTest

### DIFF
--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -23,6 +23,36 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test 'GET /api/submission/ids/biosample with API_KEY returns the submission ids' do
+    fake = Object.new
+    def fake.public_submission_id_list = %w[SSUB000001 SSUB000002]
+
+    BioSampleSubmitter.stub :new, fake do
+      get '/api/submission/ids/biosample', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :success
+    assert_equal %w[SSUB000001 SSUB000002], JSON.parse(response.body)
+  end
+
+  test 'GET /api/submission/ids/bioproject with API_KEY returns the submission ids' do
+    fake = Object.new
+    def fake.public_submission_id_list = %w[PSUB000001]
+
+    BioProjectSubmitter.stub :new, fake do
+      get '/api/submission/ids/bioproject', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :success
+    assert_equal %w[PSUB000001], JSON.parse(response.body)
+  end
+
+  test 'GET /api/submission/ids/:filetype with unknown filetype returns 400' do
+    get '/api/submission/ids/unknown', headers: {'HTTP_API_KEY' => 'curator'}
+    assert_response :bad_request
+    assert_equal 'Invalid filetype', JSON.parse(response.body)['message']
+  end
+
   # 過去に submission_id_list の rescue 節が代入式 (`ret[:status] = 'error'`)
   # で終わっていて、本来 ret hash を返すべきところを String 'error' を返していた。
   # その結果 controller 側の `ret[:status]` が TypeError を投げ、本来の
@@ -33,6 +63,50 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
 
     BioSampleSubmitter.stub :new, fake do
       get '/api/submission/ids/biosample', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :internal_server_error
+  end
+
+  test 'GET /api/submission/:filetype/:id with API_KEY returns the submission XML' do
+    fake = Object.new
+    def fake.output_xml_file(_submission_id, output)
+      File.write(output, '<BioSampleSet/>')
+    end
+
+    BioSampleSubmitter.stub :new, fake do
+      get '/api/submission/biosample/SSUB000001', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :success
+    assert_equal 'application/xml', response.media_type
+    assert_match '<BioSampleSet', response.body
+  end
+
+  test 'GET /api/submission/:filetype/:id with unknown filetype returns 400' do
+    get '/api/submission/unknown/SSUB000001', headers: {'HTTP_API_KEY' => 'curator'}
+    assert_response :bad_request
+    assert_equal 'Invalid filetype or submission_id', JSON.parse(response.body)['message']
+  end
+
+  test 'GET /api/submission/:filetype/:id returns 400 when submitter does not write the file' do
+    fake = Object.new
+    def fake.output_xml_file(_submission_id, _output) = nil
+
+    BioSampleSubmitter.stub :new, fake do
+      get '/api/submission/biosample/SSUB999999', headers: {'HTTP_API_KEY' => 'curator'}
+    end
+
+    assert_response :bad_request
+    assert_equal 'Invalid filetype or submission_id', JSON.parse(response.body)['message']
+  end
+
+  test 'GET /api/submission/:filetype/:id returns 500 when submitter raises' do
+    fake = Object.new
+    def fake.output_xml_file(_submission_id, _output) = raise(StandardError, 'boom')
+
+    BioSampleSubmitter.stub :new, fake do
+      get '/api/submission/biosample/SSUB000001', headers: {'HTTP_API_KEY' => 'curator'}
     end
 
     assert_response :internal_server_error


### PR DESCRIPTION
## Summary

Add 7 tests to `SubmissionsControllerTest` covering the previously-unexercised success and validation branches of `#ids` and `#show`.

| Case | Endpoint | Status |
|---|---|---|
| ids success (biosample) | `GET /api/submission/ids/biosample` | 200 + JSON array |
| ids success (bioproject) | `GET /api/submission/ids/bioproject` | 200 + JSON array |
| ids unknown filetype | `GET /api/submission/ids/unknown` | 400 'Invalid filetype' |
| show success | `GET /api/submission/biosample/SSUB000001` | 200 + application/xml |
| show unknown filetype | `GET /api/submission/unknown/SSUB000001` | 400 |
| show no output | submitter does not write the file | 400 |
| show error | submitter raises | 500 |

Stubs reuse the existing `BioSampleSubmitter.stub :new, fake` pattern.

## Why

Until this PR, the only paths exercised were 401 (no/wrong API_KEY) and a single 500. The success path and the 400 'invalid filetype' branch were not covered, so a regression in Submitter dispatch (e.g. the `submision` CLI typo fixed in ddad9f0, or any future filetype-routing tweak) would not be caught — same kind of coverage gap as the one PR #211 closed for `PackagesController`.

## Test plan

- [x] `bin/rails test test/controllers/submissions_controller_test.rb` (12 runs, 21 assertions, 0 failures)
- [x] `bin/rails test` full suite (339 runs, 2600 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)