### PR TITLE
Cover the success / running paths in ValidationsControllerTest

### DIFF
--- a/test/controllers/validations_controller_test.rb
+++ b/test/controllers/validations_controller_test.rb
@@ -1,6 +1,19 @@
 require 'test_helper'
+require 'minitest/mock'
+require 'securerandom'
 
 class ValidationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @data_dir = Dir.mktmpdir('validator_data_test')
+    @original_path = Rails.configuration.validator['api_log']['path']
+    Rails.configuration.validator['api_log']['path'] = @data_dir
+  end
+
+  teardown do
+    Rails.configuration.validator['api_log']['path'] = @original_path
+    FileUtils.rm_rf(@data_dir)
+  end
+
   test 'GET /api/validation/:uuid with unknown uuid returns 404 Validation not found' do
     get '/api/validation/00000000-0000-0000-0000-000000000000'
     assert_response :not_found
@@ -23,5 +36,101 @@ class ValidationsControllerTest < ActionDispatch::IntegrationTest
     get '/api/validation/00000000-0000-0000-0000-000000000000/biosample/autocorrect'
     assert_response :not_found
     assert_match 'Auto-correct data not found', JSON.parse(response.body)['message']
+  end
+
+  test 'POST /api/validation accepts a biosample submission and returns the uuid' do
+    fake_validator = Object.new
+    def fake_validator.execute(params)
+      File.write(params[:output], JSON.generate({status: 'success'}))
+    end
+
+    Validator.stub :new, fake_validator do
+      post '/api/validation', params: {biosample: '<BioSampleSet/>'}
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_match(/\A[0-9a-f-]{36}\z/, body['uuid'])
+    assert_equal 'accepted', body['status']
+    assert body['start_time']
+
+    save_dir = File.join(@data_dir, body['uuid'][0..1], body['uuid'])
+    assert File.exist?(File.join(save_dir, 'status.json'))
+    assert File.exist?(File.join(save_dir, 'biosample', 'biosample'))
+  end
+
+  test 'GET /api/validation/:uuid returns the merged status + result' do
+    uuid = stage_validation(status: 'finished', result: {'status' => 'success', 'messages' => []})
+
+    get "/api/validation/#{uuid}"
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 'finished', body['status']
+    assert_equal({'status' => 'success', 'messages' => []}, body['result'])
+  end
+
+  test 'GET /api/validation/:uuid returns 400 while still running' do
+    uuid = stage_validation(status: 'running')
+
+    get "/api/validation/#{uuid}"
+
+    assert_response :bad_request
+    assert_equal 'Validation process has not finished yet', JSON.parse(response.body)['message']
+  end
+
+  test 'GET /api/validation/:uuid/status returns the status JSON' do
+    uuid = stage_validation(status: 'running')
+
+    get "/api/validation/#{uuid}/status"
+
+    assert_response :success
+    assert_equal 'application/json', response.media_type
+    assert_equal 'running', JSON.parse(response.body)['status']
+  end
+
+  test 'GET /api/validation/:uuid/:filetype returns the uploaded file' do
+    uuid     = SecureRandom.uuid
+    file_dir = File.join(@data_dir, uuid[0..1], uuid, 'biosample')
+    FileUtils.mkdir_p(file_dir)
+    File.write(File.join(file_dir, 'sample.xml'), '<BioSampleSet/>')
+
+    get "/api/validation/#{uuid}/biosample"
+
+    assert_response :success
+    assert_equal 'application/xml', response.media_type
+    assert_match '<BioSampleSet', response.body
+  end
+
+  test 'GET /api/validation/:uuid/:filetype/autocorrect returns the annotated file' do
+    uuid     = stage_validation(status: 'finished', result: {'status' => 'success'})
+    file_dir = File.join(@data_dir, uuid[0..1], uuid, 'biosample')
+    FileUtils.mkdir_p(file_dir)
+    File.write(File.join(file_dir, 'sample.xml'), '<BioSampleSet/>')
+
+    fake_annotator = Object.new
+    def fake_annotator.create_annotated_file(_org, _result, output, _filetype, _accept)
+      File.write(output, '<BioSampleSet annotated="yes"/>')
+      {status: 'succeed', file_path: output, file_type: 'xml'}
+    end
+
+    AutoAnnotator.stub :new, fake_annotator do
+      get "/api/validation/#{uuid}/biosample/autocorrect"
+    end
+
+    assert_response :success
+    assert_match 'annotated="yes"', response.body
+  end
+
+  private
+
+  def stage_validation(status:, result: nil)
+    uuid     = SecureRandom.uuid
+    save_dir = File.join(@data_dir, uuid[0..1], uuid)
+    FileUtils.mkdir_p(save_dir)
+    File.write(File.join(save_dir, 'status.json'),
+               JSON.generate({uuid: uuid, status: status, start_time: Time.now}))
+    File.write(File.join(save_dir, 'result.json'), JSON.generate(result)) if result
+    uuid
   end
 end


### PR DESCRIPTION
## Summary

Add 6 tests for `ValidationsController` covering paths that were entirely uncovered until now (the existing 4 tests only hit the 404 not-found branches):

| Case | Endpoint | Expected |
|---|---|---|
| accepted | `POST /api/validation` (biosample) | 200 + uuid, status.json + saved upload on disk |
| finished | `GET /api/validation/:uuid` | 200, merged `status` + `result` |
| running | `GET /api/validation/:uuid` | 400 'Validation process has not finished yet' |
| status | `GET /api/validation/:uuid/status` | 200, status.json contents |
| file | `GET /api/validation/:uuid/:filetype` | 200, the uploaded XML body |
| autocorrect | `GET /api/validation/:uuid/:filetype/autocorrect` | 200, annotated XML body |

Each test isolates the on-disk state under a per-test `Dir.mktmpdir`, swapped into `Rails.configuration.validator['api_log']['path']` for the duration of the test, so the suite never touches the real `logs/` directory. `Validator.new` and `AutoAnnotator.new` are stubbed via `Minitest::Mock` so the controller flow can be exercised without spinning up the full validation pipeline.

## Out of scope (follow-up)

While writing these tests I confirmed `valid_file_combination?` is effectively dead in Rack 3:

```ruby
form_vars   = input.read              # multipart body, e.g. `--BOUNDARY\r\nContent-Disposition: ...`
req_params  = Rack::Utils.parse_query(Rack::Utils.escape(form_vars))
param_names = req_params['name']       # always nil in Rack 3 — no `&` separators after escape
return true unless param_names.is_a?(Array)
```

The duplicate-name and DRA-completeness checks never fire. I'll send a separate PR to either fix the parser (read multipart name fields properly) or drop the dead branch.

## Test plan

- [x] `bin/rails test test/controllers/validations_controller_test.rb` (10 runs, 31 assertions, 0 failures)
- [x] `bin/rails test` full suite (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)