### PR TITLE
Drop valid_file_combination? — never actually checked anything

### DIFF
--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -2,11 +2,6 @@ require 'securerandom'
 
 class ValidationsController < ApplicationController
   def create
-    unless valid_file_combination?
-      render_error('Invalid file combination', status: :bad_request)
-      return
-    end
-
     uuid       = SecureRandom.uuid
     save_dir   = File.join(data_dir, uuid[0..1], uuid)
     start_time = Time.now
@@ -148,33 +143,6 @@ class ValidationsController < ApplicationController
     when 'tsv'  then 'text/tab-separated-values'
     else             'application/xml'
     end
-  end
-
-  # Rack 3 で rack.request.form_input は multipart 時でも nil になり得るため、
-  # rack.input から直接読んで name フィールドの重複とセット要件をチェックする。
-  def valid_file_combination?
-    input = request.env['rack.input']
-    input.rewind if input.respond_to?(:rewind)
-    form_vars = input.read
-    input.rewind if input.respond_to?(:rewind)
-
-    req_params  = Rack::Utils.parse_query(Rack::Utils.escape(form_vars))
-    param_names = req_params['name']
-
-    return true unless param_names.is_a?(Array)
-
-    %w[biosample bioproject submission experiment run analysis].each do |kind|
-      return false if param_names.count {|n| n == %("#{kind}") } > 1
-    end
-
-    dra_types = %w[submission experiment run analysis]
-    sent      = params.keys
-
-    if dra_types.any? { sent.include?(it) }
-      return false unless sent.include?('submission') && sent.include?('experiment') && sent.include?('run')
-    end
-
-    true
   end
 
   def save_uploaded_file (output_dir, category)


### PR DESCRIPTION
## Summary

Remove `ValidationsController#valid_file_combination?` and its caller. -32 LOC, no replacement.

## Why

`valid_file_combination?` URL-escapes the whole multipart body before handing it to `parse_query`:

```ruby
req_params  = Rack::Utils.parse_query(Rack::Utils.escape(form_vars))
param_names = req_params['name']
return true unless param_names.is_a?(Array)
```

`Rack::Utils.escape` encodes both `=` and `&` (the only separators `parse_query` knows about), so the parsed result has no usable structure. `req_params['name']` has been `nil` since the Sinatra/Rack 2 days, the early `return true` always fires, and the duplicate / DRA-completeness checks below it have never run in production. This was already called out as known dead behavior in 41d8244 ('Fix /api/monitoring: Rack 3 compat + 503 on NG').

PR #214 confirmed it from the test side: every multipart shape I tried produced `param_names = nil`, so the validation block was unreachable.

The router (route constraints + dispatch on the named category list in `#create`) and `save_uploaded_file` already cover everything we actually rely on at request time. Dropping the helper just makes the code match what it was already doing.

## Test plan

- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)