### PR TITLE
Drop debug puts in Package#attribute_template_file

### DIFF
--- a/lib/package/package.rb
+++ b/lib/package/package.rb
@@ -184,7 +184,6 @@ class Package < SPARQLBase
       accept_header_list = accept_header.to_s.split(',').map(&:strip)
       return_file_format = accept_header_list.include?('text/tab-separated-values') ? 'tsv' : 'excel'
       template_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../public/template')
-      puts template_file_dir
       file_path = ''
       if return_file_format == 'tsv'
         file_path = "#{template_file_dir}/#{version}/bs/tsv/#{package_id}.tsv"
@@ -198,7 +197,7 @@ class Package < SPARQLBase
       if File.exist?(file_path)
         {status: 'success', file_path: file_path, file_type: return_file_format}
       else
-        puts "Not exist package template file: #{file_path}"
+        @log.warn("Not exist package template file: #{file_path}")
         {status: 'fail', message: 'Invalid package_id'}
       end
     rescue => ex


### PR DESCRIPTION
## Summary

- Drop the leftover `puts template_file_dir` (dumped the absolute template directory to STDOUT on every `/api/attribute_template_file` request).
- Replace the second `puts "Not exist package template file: ..."` with `@log.warn(...)` so the message lands in `validator.log` alongside the surrounding error logging instead of stdout.

## Why

Both lines surfaced as noise in the test runner output (and in `puma`'s stdout in dev/staging/production) ever since the file landed. Mentioned as a follow-up in PR #213.

## Test plan

- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)