### PR TITLE
Fix Ruby 3.4 'literal string will be frozen' warnings

### DIFF
--- a/app/models/date_format.rb
+++ b/app/models/date_format.rb
@@ -207,7 +207,7 @@ class DateFormat
     # https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html#I_programlisting4_d1e23455
     # ここでは一旦Zを消して、UTC変換メソッドで時差調整した上でZを再付与する
     if timezone_text.include?('Z') && ['+', '-'].any? {|c| timezone_text.include?(c) }
-      timezone_text.gsub!('Z', '')
+      timezone_text = timezone_text.delete('Z')
     end
     if timezone_text.chomp.strip.upcase == 'Z' # "z(local time)"や"Z"は"Z"で返す
       return 'Z'

--- a/app/models/tsv_field_validator.rb
+++ b/app/models/tsv_field_validator.rb
@@ -147,28 +147,14 @@ class TsvFieldValidator
     data.each_with_index do |row, field_idx|
       next if !ignore_field_list.nil? && ignore_field_list.include?(row['key']) # 除外fieldはスキップ
       unless row['key'].ascii_only? # Field名のチェック
-        disp_txt = '' # 名前のどこにnon ascii文字があるか示すメッセージを作成
-        row['key'].each_char do |ch|
-          if ch.ascii_only?
-            disp_txt << ch.to_s
-          else
-            disp_txt << '[### Non-ASCII character ###]'
-          end
-        end
+        disp_txt = row['key'].each_char.map {|ch| ch.ascii_only? ? ch : '[### Non-ASCII character ###]' }.join
         invalid_list.push({field_name: row['key'],  disp_txt: disp_txt, field_idx: field_idx})
       end
       next if row['values'].nil?
       row['values'].each_with_index do |value, value_idx|  # Field値のチェック
         next if value.nil?
         next if value.ascii_only?
-        disp_txt = '' # 値のどこにnon ascii文字があるか示すメッセージを作成
-        value.each_char do |ch|
-          if ch.ascii_only?
-            disp_txt << ch.to_s
-          else
-            disp_txt << '[### Non-ASCII character ###]'
-          end
-        end
+        disp_txt = value.each_char.map {|ch| ch.ascii_only? ? ch : '[### Non-ASCII character ###]' }.join
         invalid_list.push({field_name: row['key'], value: value, disp_txt: disp_txt, field_idx: field_idx, value_idx: value_idx})
       end
     end


### PR DESCRIPTION
## Summary

Silence the two recurring `warning: literal string will be frozen in the future` messages emitted on every test run.

| File | Site | Fix |
|---|---|---|
| `app/models/date_format.rb` | `timezone_text.gsub!('Z', '')` reaches the `'Z'` literal assigned a few branches earlier | use `String#delete` and reassign |
| `app/models/tsv_field_validator.rb` | two `disp_txt = ''` + `<<` loops | rewrite as `each_char.map { ... }.join` |

No behavior change.

## Test plan

- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)