### PR TITLE
Silence Roo wrong-extension warn in JVarValidator#load_excel

### DIFF
--- a/app/models/jvar_validator.rb
+++ b/app/models/jvar_validator.rb
@@ -60,7 +60,9 @@ class JVarValidator < ValidatorBase
     xlsx = nil
     begin
       # 結合セルは対象セルの全てに同じ値を埋めるモード
-      xlsx = Roo::Excelx.new(data_xlsx, {expand_merged_ranges: true})
+      # file_warning: :ignore — Roo の拡張子チェックで warn が出るのを抑える。
+      # 中身がパースできない場合は後段で例外が上がるので、ここで弾く必要はない。
+      xlsx = Roo::Excelx.new(data_xlsx, expand_merged_ranges: true, file_warning: :ignore)
     rescue => ex
       annotation = [
         {key: 'Excel file', value: @data_file},


### PR DESCRIPTION
## Summary

Pass `file_warning: :ignore` to `Roo::Excelx.new` in `JVarValidator#load_excel` so Roo's default extension pre-check stops printing

```
use Roo::Excelx.new to handle .xlsx or .xlsm spreadsheet files. This has .txt
```

to stderr on every test run.

## Why

The `jvar_validator_test.rb` test `1_not_well_format_excel_ng.txt` deliberately feeds a `.txt` file to exercise the `JV_R0001 'failed to load excel'` validation. With the default `file_warning: :error`, Roo `warn`s before raising; the raise is caught by `load_excel`'s rescue and the rule fires correctly — the noisy warn was the only loose thread. With `:ignore`, Roo skips the extension pre-check; an unparseable file body still raises later in Roo, caught by the same rescue.

## Test plan

- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips, no warnings, no Roo notices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)