### PR TITLE
Drop bin/ddbj_validator and Validator CLI mode

### DIFF
--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -1,4 +1,3 @@
-require 'optparse'
 require 'logger'
 require 'securerandom'
 require 'yaml'
@@ -7,14 +6,6 @@ require 'fileutils'
 # Validator main class
 class Validator
     FILETYPES = %w[all_db biosample bioproject submission experiment run analysis jvar trad_anno trad_seq trad_agp metabobank_idf metabobank_sdrf].freeze
-
-    # Runs validator from command line
-    # @param [Array] argv command line parameters
-    # @return [void]
-    def self.run(argv)
-      params = Validator.parse_param!(argv)
-      new().execute(params)
-    end
 
     # constructor
     def initialize
@@ -76,16 +67,6 @@ class Validator
           JSON.generate(ret)
           FileUtils.rm(running_file)
           return
-        end
-
-        # if exist user/password
-        unless params[:user].nil? and params[:password].nil?
-          if params[:user] == 'admin' and params[:password] == 'admin'
-            # TODO get xml with submission?
-          else
-            puts 'Unauthorized' # return error
-            return
-          end
         end
 
         # validate
@@ -257,53 +238,6 @@ class Validator
       result
     end
 
-    #### Parse the arguments
-
-    # Analyze the arguments of command line
-    # @return Hash obtained as a result of analyzing command line arguments
-    def self.parse_param!(argv)
-      options = {}
-      command_parser      = create_command_parser(options)
-      # Analyze the arguments
-      begin
-        command_parser.order! argv
-      rescue OptionParser::MissingArgument, OptionParser::InvalidOption, ArgumentError => e
-        # TODO return error
-        abort e.message
-      end
-      options
-    end
-
-    # Create new OptionParser for this application
-    # @return [OptionsParser]
-    def self.create_command_parser(options)
-      OptionParser.new do |opt|
-        opt.banner = "Usage: #{opt.program_name} [-s|--biosample] [-p|--bioproject] [-t|--submission] [-e|--experiment] [-r|--run] [-a|--analysis] -o|--output [--user] [--password]"
-
-        opt.on_head('-h', '--help', 'Show this message') do |v|
-          puts opt.help
-          exit
-        end
-
-        opt.on_head('-v', '--version', 'Show program version') do |v|
-          opt.version = '0.9.0' # #TODO conf
-          puts opt.ver
-          exit
-        end
-
-        opt.separator ''
-        opt.on('-s VAL', '--biosample=file',  'biosample xml file path')        {|v| options[:biosample] = v }
-        opt.on('-p VAL', '--bioproject=file', 'bioproject xml file path')       {|v| options[:bioproject] = v }
-        opt.on('-t VAL', '--submission=file', 'submission xml file path')       {|v| options[:submission] = v }
-        opt.on('-e VAL', '--experiment=file', 'experiment xml file path')       {|v| options[:experiment] = v }
-        opt.on('-r VAL', '--run=file',        'run xml file path')              {|v| options[:run] = v }
-        opt.on('-a VAL', '--analysis=file',   'analysis xml file path')         {|v| options[:analysis] = v }
-        opt.on('-o VAL', '--output=file',     'output file path')               {|v| options[:output] = v }
-        opt.on('--user=VAL',                  'user name')               {|v| options[:output] = v }
-        opt.on('--password=VAL',              'password')               {|v| options[:output] = v }
-      end
-    end
-
     #### Parse the validation result
 
     # error_listから統計情報を計算して返す
@@ -368,6 +302,4 @@ class Validator
       File.write(tmp, content)
       File.rename(tmp, path)
     end
-
-    private_class_method :create_command_parser
 end

--- a/bin/ddbj_validator
+++ b/bin/ddbj_validator
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path('../../lib/validator/validator.rb', __FILE__)
-
-Validator.run(ARGV)


### PR DESCRIPTION
## Summary

- Delete `bin/ddbj_validator`. It has been broken since PR #217 — it `require`s `lib/validator/validator.rb`, which was moved to `app/models/validator.rb`. Nothing else in the repo invokes it.
- Drop the now-orphan CLI plumbing in `app/models/validator.rb`:
  - `self.run`, `self.parse_param!`, `self.create_command_parser`
  - `private_class_method :create_command_parser`
  - `require 'optparse'`
- Drop the dead `params[:user] == 'admin'` admin-auth block inside `Validator#execute`. It's only reachable via CLI argv — the web controller calls `Validator.new.execute(params)` directly with no `:user`/`:password` keys, so the block was always a no-op for HTTP traffic.

## Why

Even before the lib/→app/models move, the binary was unreferenced (no `bin/`/`compose*.yaml`/`deploy_tools/`/`.github/workflows/` callers). After the move it has been silently broken; nobody has filed a bug. Reflecting reality.

Web entry points — `ValidationsController#create`, `MonitoringController`, `TestValidator` — use `Validator.new.execute(params)` directly and are unaffected.

## Test plan

- [x] `bin/rubocop` (100 files, 0 offenses)
- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)