### PR TITLE
Inline read_config into each validator constructor

### DIFF
--- a/app/models/analysis_validator.rb
+++ b/app/models/analysis_validator.rb
@@ -9,32 +9,13 @@ class AnalysisValidator < ValidatorBase
   #
   def initialize
     super
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
+    conf_dir = Rails.root.join('conf/dra')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_dra.json').read)
+    @conf[:xsd_path]          = conf_dir.join('xsd/SRA.analysis.xsd').to_s
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_dra.json')) # TODO auto update when genereted
-      config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/SRA.analysis.xsd')
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/bioproject_tsv_validator.rb
+++ b/app/models/bioproject_tsv_validator.rb
@@ -8,36 +8,17 @@ class BioProjectTsvValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
+    super
+    conf_dir = Rails.root.join('conf/bioproject')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_bioproject.json').read)
+    @conf[:field_settings]    = JSON.parse(conf_dir.join('field_settings.json').read)
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @json_schema = JSON.parse(File.read(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject/schema.json')))
-    @tsv_validator = TsvFieldValidator.new()
-    @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_bioproject.json'))
-      config[:field_settings] = JSON.parse(File.read(config_file_dir + '/field_settings.json'))
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @json_schema       = JSON.parse(conf_dir.join('schema.json').read)
+    @tsv_validator     = TsvFieldValidator.new
+    @org_validator     = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/bioproject_validator.rb
+++ b/app/models/bioproject_validator.rb
@@ -8,34 +8,15 @@ class BioProjectValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/bioproject')))
+    super
+    conf_dir = Rails.root.join('conf/bioproject')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_bioproject.json').read)
+    @conf[:xsd_path]          = conf_dir.join('xsd/Package.xsd').to_s
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_bioproject.json')) # TODO auto update when genereted
-      config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/Package.xsd')
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @org_validator     = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/biosample_validator.rb
+++ b/app/models/biosample_validator.rb
@@ -16,58 +16,41 @@ class BioSampleValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/biosample')))
-    @date_format = DateFormat.new(@conf)
+    super
+    conf_dir = Rails.root.join('conf/biosample')
 
-    @error_list = error_list = []
+    # pub リポジトリ (github.com/ddbj/pub) と coll_dump は本番ではそれぞれ外部ディレクトリが
+    # conf/pub / conf/coll_dump にバインドマウントされる。テストで本物のマウントを用意する代わりに、
+    # env で test/fixtures/ 配下のスナップショットを指せるようにしておく
+    pub_dir        = ENV['DDBJ_VALIDATOR_APP_PUB_DIR']        || conf_dir.join('../pub').to_s
+    coll_dump_file = ENV['DDBJ_VALIDATOR_APP_COLL_DUMP_FILE'] || conf_dir.join('../coll_dump/coll_dump.txt').to_s
 
-    @validation_config = @conf[:validation_config] # need?
-    @xml_convertor = XmlConvertor.new
-    @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    @institution_list = CollDump.parse(@conf[:institution_list_file])
-    @tsv_validator = TsvColumnValidator.new()
-    @package_version = @conf[:biosample]['package_version']
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
+    @conf[:validation_config]       = JSON.parse(conf_dir.join('rule_config_biosample.json').read)
+    @conf[:null_accepted]           = JSON.parse(conf_dir.join('null_accepted.json').read)
+    @conf[:null_not_recommended]    = JSON.parse(conf_dir.join('null_not_recommended.json').read)
+    @conf[:cv_attr]                 = JSON.parse(conf_dir.join('controlled_terms.json').read)
+    @conf[:ref_attr]                = JSON.parse(conf_dir.join('reference_attributes.json').read)
+    @conf[:ts_attr]                 = JSON.parse(conf_dir.join('timestamp_attributes.json').read)
+    @conf[:int_attr]                = JSON.parse(conf_dir.join('integer_attributes.json').read)
+    @conf[:special_chars]           = JSON.parse(conf_dir.join('special_characters.json').read)
+    @conf[:country_list]            = JSON.parse(File.read("#{pub_dir}/docs/common/country_list.json"))
+    @conf[:historical_country_list] = JSON.parse(File.read("#{pub_dir}/docs/common/historical_country_list.json"))
+    @conf[:valid_country_list]      = @conf[:country_list] + @conf[:historical_country_list]
+    @conf[:convert_date_format]     = JSON.parse(conf_dir.join('convert_date_format.json').read)
+    @conf[:ddbj_date_format]        = JSON.parse(conf_dir.join('ddbj_date_format.json').read)
+    @conf[:invalid_strain_value]    = JSON.parse(conf_dir.join('invalid_strain_value.json').read)
+    @conf[:json_schema]             = JSON.parse(conf_dir.join('schema.json').read)
+    @conf[:institution_list_file]   = coll_dump_file
 
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_biosample.json')) # TODO auto update when genereted
-      config[:null_accepted] = JSON.parse(File.read(config_file_dir + '/null_accepted.json'))
-      config[:null_not_recommended] = JSON.parse(File.read(config_file_dir + '/null_not_recommended.json'))
-      config[:cv_attr] = JSON.parse(File.read(config_file_dir + '/controlled_terms.json'))
-      config[:ref_attr] = JSON.parse(File.read(config_file_dir + '/reference_attributes.json'))
-      config[:ts_attr] = JSON.parse(File.read(config_file_dir + '/timestamp_attributes.json'))
-      config[:int_attr] = JSON.parse(File.read(config_file_dir + '/integer_attributes.json'))
-      config[:special_chars] = JSON.parse(File.read(config_file_dir + '/special_characters.json'))
-      # pub リポジトリ (github.com/ddbj/pub) と coll_dump は本番ではそれぞれ外部ディレクトリが
-      # conf/pub / conf/coll_dump にバインドマウントされる。テストで本物のマウントを用意する代わりに、
-      # env で test/fixtures/ 配下のスナップショットを指せるようにしておく
-      pub_dir        = ENV.fetch('DDBJ_VALIDATOR_APP_PUB_DIR')        { config_file_dir + '/../pub' }
-      coll_dump_file = ENV.fetch('DDBJ_VALIDATOR_APP_COLL_DUMP_FILE') { config_file_dir + '/../coll_dump/coll_dump.txt' }
-      config[:country_list] = JSON.parse(File.read(pub_dir + '/docs/common/country_list.json'))
-      config[:historical_country_list] = JSON.parse(File.read(pub_dir + '/docs/common/historical_country_list.json'))
-      config[:valid_country_list] = config[:country_list] + config[:historical_country_list]
-      config[:convert_date_format] = JSON.parse(File.read(config_file_dir + '/convert_date_format.json'))
-      config[:ddbj_date_format] = JSON.parse(File.read(config_file_dir + '/ddbj_date_format.json'))
-      config[:invalid_strain_value] = JSON.parse(File.read(config_file_dir + '/invalid_strain_value.json'))
-      config[:json_schema] = JSON.parse(File.read(config_file_dir + '/schema.json'))
-      config[:institution_list_file] = coll_dump_file
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @date_format       = DateFormat.new(@conf)
+    @validation_config = @conf[:validation_config]
+    @xml_convertor     = XmlConvertor.new
+    @org_validator     = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
+    @institution_list  = CollDump.parse(@conf[:institution_list_file])
+    @tsv_validator     = TsvColumnValidator.new
+    @package_version   = @conf[:biosample]['package_version']
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/combination_validator.rb
+++ b/app/models/combination_validator.rb
@@ -9,31 +9,12 @@ class CombinationValidator < ValidatorBase
   #
   def initialize
     super
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
+    conf_dir = Rails.root.join('conf/dra')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_dra.json').read)
+    @conf[:platform_filetype] = JSON.parse(conf_dir.join('platform_filetype.json').read)
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_dra.json')) # TODO auto update when genereted
-      config[:platform_filetype] = JSON.parse(File.read(config_file_dir + '/platform_filetype.json'))
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @error_list        = []
   end
 
   #

--- a/app/models/experiment_validator.rb
+++ b/app/models/experiment_validator.rb
@@ -9,32 +9,13 @@ class ExperimentValidator < ValidatorBase
   #
   def initialize
     super
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
+    conf_dir = Rails.root.join('conf/dra')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_dra.json').read)
+    @conf[:xsd_path]          = conf_dir.join('xsd/SRA.experiment.xsd').to_s
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_dra.json')) # TODO auto update when genereted
-      config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/SRA.experiment.xsd')
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/metabobank_idf_validator.rb
+++ b/app/models/metabobank_idf_validator.rb
@@ -8,34 +8,15 @@ class MetaboBankIdfValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_idf')))
+    super
+    conf_dir = Rails.root.join('conf/metabobank_idf')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_metabobank_idf.json').read)
+    @conf[:field_settings]    = JSON.parse(conf_dir.join('field_settings.json').read)
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @json_schema = JSON.parse(File.read(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_idf/schema.json')))
-    @tsv_validator = TsvFieldValidator.new()
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_metabobank_idf.json')) # TODO auto update when genereted
-      config[:field_settings] = JSON.parse(File.read(config_file_dir + '/field_settings.json'))
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @json_schema       = JSON.parse(conf_dir.join('schema.json').read)
+    @tsv_validator     = TsvFieldValidator.new
+    @error_list        = []
   end
 
   #

--- a/app/models/metabobank_sdrf_validator.rb
+++ b/app/models/metabobank_sdrf_validator.rb
@@ -8,33 +8,14 @@ class MetaboBankSdrfValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_sdrf')))
+    super
+    conf_dir = Rails.root.join('conf/metabobank_sdrf')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_metabobank_sdrf.json').read)
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @json_schema = JSON.parse(File.read(File.absolute_path(File.dirname(__FILE__) + '/../../conf/metabobank_sdrf/schema.json')))
-    @tsv_validator = TsvColumnValidator.new()
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_metabobank_sdrf.json')) # TODO auto update when genereted
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @json_schema       = JSON.parse(conf_dir.join('schema.json').read)
+    @tsv_validator     = TsvColumnValidator.new
+    @error_list        = []
   end
 
   #

--- a/app/models/run_validator.rb
+++ b/app/models/run_validator.rb
@@ -9,32 +9,13 @@ class RunValidator < ValidatorBase
   #
   def initialize
     super
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
+    conf_dir = Rails.root.join('conf/dra')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_dra.json').read)
+    @conf[:xsd_path]          = conf_dir.join('xsd/SRA.run.xsd').to_s
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_dra.json')) # TODO auto update when genereted
-      config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/SRA.run.xsd')
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #

--- a/app/models/submission_validator.rb
+++ b/app/models/submission_validator.rb
@@ -9,32 +9,13 @@ class SubmissionValidator < ValidatorBase
   #
   def initialize
     super
-    @conf.merge!(read_config(File.absolute_path(File.dirname(__FILE__) + '/../../conf/dra')))
+    conf_dir = Rails.root.join('conf/dra')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_dra.json').read)
+    @conf[:xsd_path]          = conf_dir.join('xsd/SRA.submission.xsd').to_s
 
-    @error_list = error_list = []
-
-    @validation_config = @conf[:validation_config] # need?
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
-  end
-
-  #
-  # 各種設定ファイルの読み込み
-  #
-  # ==== Args
-  # config_file_dir: 設定ファイル設置ディレクトリ
-  #
-  #
-  def read_config (config_file_dir)
-    config = {}
-    begin
-      config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_dra.json')) # TODO auto update when genereted
-      config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/SRA.submission.xsd')
-      config
-    rescue => ex
-      message = "Failed to parse the setting file. Please check the config file below.\n"
-      message += "#{ex.message} (#{ex.class})"
-      raise StandardError, message, ex.backtrace
-    end
+    @validation_config = @conf[:validation_config]
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #


### PR DESCRIPTION
## Summary

Inline each `*_validator.rb`'s `read_config(config_file_dir)` method into its constructor, drop the rescue wrapper, and switch path computation to `Rails.root.join('conf/...')` (Pathname).

## Why

Each of the 10 validators carried a near-copy of:

```ruby
def read_config (config_file_dir)
  config = {}
  begin
    config[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_X.json'))
    config[:xsd_path] = File.absolute_path(config_file_dir + '/xsd/SRA.X.xsd')
    config
  rescue => ex
    message = "Failed to parse the setting file. Please check the config file below.\n#{ex.message} (#{ex.class})"
    raise StandardError, message, ex.backtrace
  end
end
```

The rescue rewrites whatever the underlying error was (almost always `JSON::ParserError` or `Errno::ENOENT`) into a generic `StandardError` that no other code matches on and that loses some of the original diagnosis. No tests reference the message; no callers exist outside each validator's own `initialize`. So the loop is just deletable.

After inlining, each constructor reads the JSON files directly with `Rails.root.join('conf/X').join('foo.json').read`, which is also consistent with the recent `Rails.root.glob` / `Pathname#read` style applied to tests.

`File.absolute_path(File.dirname(__FILE__) + '/../../conf/X')` happened to resolve correctly from `app/models/` because the depth is the same as the original `lib/validator/`, but switching to `Rails.root.join` removes the implicit dependency on file location.

Drop the dangling `error_list = []` shadowing local that was assigned but never read.

## Stats

- 10 files changed
- -282 / +94, net **-188 LOC**

## Test plan

- [x] `bin/rubocop` (100 files, 0 offenses)
- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)