### PR TITLE
Switch the last 3 conf/public path lookups to Rails.root

### DIFF
--- a/app/models/jvar_validator.rb
+++ b/app/models/jvar_validator.rb
@@ -8,16 +8,14 @@ class JVarValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    config_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../conf/jvar')
-    xlsx_error_log = File.absolute_path(@conf[:log_dir] + '/excel_error.log')
+    super
+    conf_dir = Rails.root.join('conf/jvar')
+    @conf[:validation_config] = JSON.parse(conf_dir.join('rule_config_jvar.json').read)
+    @conf[:sheet_list]        = JSON.parse(conf_dir.join('sheet_list.json').read)
 
-    @log = Logger.new(xlsx_error_log)
-    @conf[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_jvar.json'))
-    @conf[:sheet_list] = JSON.parse(File.read(config_file_dir + '/sheet_list.json'))
-
-    @error_list = error_list = []
-    @validation_config = @conf[:validation_config] # need?
+    @log               = Logger.new(File.join(@conf[:log_dir], 'excel_error.log'))
+    @validation_config = @conf[:validation_config]
+    @error_list        = []
   end
 
   #

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -183,7 +183,7 @@ class Package < SPARQLBase
       # accept header から希望ファイル形式を決める
       accept_header_list = accept_header.to_s.split(',').map(&:strip)
       return_file_format = accept_header_list.include?('text/tab-separated-values') ? 'tsv' : 'excel'
-      template_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../public/template')
+      template_file_dir = Rails.root.join('public/template')
       file_path = ''
       if return_file_format == 'tsv'
         file_path = "#{template_file_dir}/#{version}/bs/tsv/#{package_id}.tsv"

--- a/app/models/trad_validator.rb
+++ b/app/models/trad_validator.rb
@@ -10,20 +10,15 @@ class TradValidator < ValidatorBase
   # Initializer
   #
   def initialize
-    super()
-    config_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../conf/trad')
+    super
+    @conf[:validation_config]          = JSON.parse(Rails.root.join('conf/trad/rule_config_trad.json').read)
+    @conf[:locus_tag_require_features] = JSON.parse(Rails.root.join('conf/trad/locus_tag_require_features.json').read)
+    @conf[:bs_null_accepted]           = JSON.parse(Rails.root.join('conf/biosample/null_accepted.json').read)
 
-    @conf[:validation_config] = JSON.parse(File.read(config_file_dir + '/rule_config_trad.json'))
-    @conf[:locus_tag_require_features] = JSON.parse(File.read(config_file_dir + '/locus_tag_require_features.json'))
-
-    bs_config_file_dir = File.absolute_path(File.dirname(__FILE__) + '/../../conf/biosample')
-    @conf[:bs_null_accepted] = JSON.parse(File.read(bs_config_file_dir + '/null_accepted.json'))
-
-    @org_validator = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
-    @error_list = error_list = []
-    @validation_config = @conf[:validation_config] # need?
-
-    @db_validator = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @validation_config = @conf[:validation_config]
+    @org_validator     = OrganismValidator.new(@conf[:sparql_config]['master_endpoint'], @conf[:named_graph_uri]['taxonomy'])
+    @db_validator      = DDBJDbValidator.new(@conf[:ddbj_db_config])
+    @error_list        = []
   end
 
   #


### PR DESCRIPTION
## Summary

PR #224 converted the 10 validators with `read_config` methods, but left three holdouts still computing:

```ruby
File.absolute_path(File.dirname(__FILE__) + '/../../conf/jvar')
File.absolute_path(File.dirname(__FILE__) + '/../../conf/trad')
File.absolute_path(File.dirname(__FILE__) + '/../../public/template')
```

Switch all three to `Rails.root.join(...)` for consistency with the rest of `app/models/`, which also removes their implicit dependency on `app/models/` being two levels deep from the repo root.

While here, drop the dangling `error_list = []` shadowing local in `jvar_validator` / `trad_validator` and the `# need?` comments that came along for the ride.

The `# TODO auto update when genereted` typos noted earlier were already gone — they lived inside the `read_config` methods that got inlined in #224.

## Test plan

- [x] `bin/rubocop` (100 files, 0 offenses)
- [x] `bin/rails test` (350 runs, 2636 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)