### PR TITLE
Constrain :filetype in routes to lowercase letters / underscore

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -159,7 +159,7 @@
       "cwe_id": [
         22
       ],
-      "note": "params[:uuid] is constrained by the route. params[:filetype] is unconstrained but bounded to data_dir/<prefix>/<uuid>/, and the action returns 400 unless exactly one file matches."
+      "note": "Both params[:uuid] (/[0-9a-f-]+/) and params[:filetype] (/[a-z][a-z_]*/) are constrained by the route, and the action returns 404 unless exactly one file matches."
     },
     {
       "warning_type": "File Access",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,11 @@ Rails.application.routes.draw do
     post 'validation'                             => 'validations#create'
     get  'validation/:uuid'                       => 'validations#show',        constraints: {uuid: /[0-9a-f-]+/}
     get  'validation/:uuid/status'                => 'validations#status',      constraints: {uuid: /[0-9a-f-]+/}
-    get  'validation/:uuid/:filetype'             => 'validations#file',        constraints: {uuid: /[0-9a-f-]+/}
-    get  'validation/:uuid/:filetype/autocorrect' => 'validations#autocorrect', constraints: {uuid: /[0-9a-f-]+/}
+    get  'validation/:uuid/:filetype'             => 'validations#file',        constraints: {uuid: /[0-9a-f-]+/, filetype: /[a-z][a-z_]*/}
+    get  'validation/:uuid/:filetype/autocorrect' => 'validations#autocorrect', constraints: {uuid: /[0-9a-f-]+/, filetype: /[a-z][a-z_]*/}
 
-    get  'submission/ids/:filetype'            => 'submissions#ids'
-    get  'submission/:filetype/:submission_id' => 'submissions#show', submission_id: /[^\/]+/
+    get  'submission/ids/:filetype'            => 'submissions#ids', constraints: {filetype: /[a-z][a-z_]*/}
+    get  'submission/:filetype/:submission_id' => 'submissions#show', constraints: {filetype: /[a-z][a-z_]*/, submission_id: /[^\/]+/}
 
     get  'monitoring' => 'monitoring#show'
 

--- a/test/controllers/validations_controller_test.rb
+++ b/test/controllers/validations_controller_test.rb
@@ -38,6 +38,11 @@ class ValidationsControllerTest < ActionDispatch::IntegrationTest
     assert_match 'Auto-correct data not found', JSON.parse(response.body)['message']
   end
 
+  test 'GET /api/validation/:uuid/:filetype rejects traversal in filetype' do
+    get '/api/validation/00000000-0000-0000-0000-000000000000/..%2F'
+    assert_response :not_found
+  end
+
   test 'POST /api/validation accepts a biosample submission and returns the uuid' do
     fake_validator = Object.new
     def fake_validator.execute(params)


### PR DESCRIPTION
## Summary

Add a `filetype: /[a-z][a-z_]*/` route constraint to all four route entries that previously accepted any value:

```
validation/:uuid/:filetype
validation/:uuid/:filetype/autocorrect
submission/ids/:filetype
submission/:filetype/:submission_id
```

## Why

A request like `/api/validation/<uuid>/..` previously reached `ValidationsController#file`, where

```ruby
Dir.glob(File.join(data_dir, prefix, uuid, '..', '*'))
```

would list neighboring UUID dirs at the same prefix and pick the first one. The disclosure was bounded — the action returned 404 unless `file_list.size == 1` — but it shouldn't get that far in the first place.

The new pattern matches every legitimate filetype the controllers accept (biosample, bioproject, submission, run, experiment, jvar, trad_anno, trad_seq, trad_agp, metabobank_idf, metabobank_sdrf, all_db, analysis) and rejects `.`, `..`, `/`, uppercase, anything else with a 404 from the router.

## Test plan

- [x] New `validations_controller_test.rb` test asserting `/api/validation/<uuid>/..%2F` → 404.
- [x] `bin/rails test` (321 runs, 2638 assertions, 0 failures, 0 errors, 0 skips)
- [x] `bin/rubocop` (100 files, 0 offenses)
- [x] `bin/brakeman --no-pager` (0 warnings, 12 ignored — note for the affected entry updated to reflect the new constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)