### PR TITLE
log_analysis: align container paths with the Rails app under /rails

### DIFF
--- a/log_analysis/Dockerfile
+++ b/log_analysis/Dockerfile
@@ -1,11 +1,7 @@
 FROM ruby:4.0.3
 
-RUN mkdir -p /usr/src/ddbj_validator/logs
-RUN mkdir -p /usr/src/ddbj_validator/shared
-RUN mkdir -p /usr/src/ddbj_validator/lib
-COPY ./create_log_pg.rb /usr/src/log_analysis/
-COPY ./Gemfile /usr/src/log_analysis/
-COPY ./Gemfile.lock /usr/src/log_analysis/
-WORKDIR /usr/src/log_analysis/
-
+# bundle install 用に Gemfile/Gemfile.lock だけ build 時にコピーする。スクリプト本体
+# (create_log_pg.rb) は実行時に compose の bind mount (/rails/log_analysis) で見える。
+COPY ./Gemfile ./Gemfile.lock /tmp/log_analysis/
+WORKDIR /tmp/log_analysis
 RUN bundle install

--- a/log_analysis/create_log_pg.rb
+++ b/log_analysis/create_log_pg.rb
@@ -8,9 +8,9 @@ require 'pg'
 require_relative '../app/models/xml_convertor'
 
 class CreateLogIndex
-  ACCESS_LOG_DIR = "/usr/src/ddbj_validator/shared/log"
-  LOG_DIR = "/usr/src/ddbj_validator/logs"
-  TSV_DIR = "/usr/src/ddbj_validator/logs/tsv"
+  ACCESS_LOG_DIR = "/rails/shared/log"
+  LOG_DIR = "/rails/logs"
+  TSV_DIR = "/rails/logs/tsv"
   @target_date = ""
   def initialize(target_date = nil)
     if target_date.nil?

--- a/log_analysis/docker-compose.yml
+++ b/log_analysis/docker-compose.yml
@@ -15,14 +15,12 @@ services:
       PGUSER: ${DDBJ_VALIDATOR_LOG_ANALYSIS_POSTGRES_USER:-postgres}
       PGPASSWORD: ${DDBJ_VALIDATOR_LOG_ANALYSIS_POSTGRES_PASSWORD:-pdb}
     user: ${UID:-0}:${DOCKER_GID:-0}
+    working_dir: /rails/log_analysis
     volumes:
       - /cm/local/apps/docker/current/bin/docker:/usr/bin/docker
       - /var/lib/docker:/var/lib/docker
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${PWD}:/usr/src/log_analysis
-      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_LOGS_DIR}:/usr/src/ddbj_validator/logs
-      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_SHARED_DIR}:/usr/src/ddbj_validator/shared
-      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_VALIDATOR_DIR}:/usr/src/ddbj_validator
+      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_VALIDATOR_DIR}:/rails
 
   postgres:
     image: postgres:9.4
@@ -40,7 +38,9 @@ services:
     volumes:
       - ${PWD}/data:/var/lib/postgresql/data
       - ${PWD}/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_LOGS_DIR}:/usr/src/ddbj_validator/logs
+      # tsv ロード用 SQL は host 側 logs/tsv/ に書かれる。psql が docker exec 経由で
+      # この postgres コンテナ内で動くので、同じパスで読めるようにマウントする。
+      - ${DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_VALIDATOR_DIR}/logs:/rails/logs
 
 networks:
   ddbj:

--- a/log_analysis/template.env
+++ b/log_analysis/template.env
@@ -4,6 +4,5 @@ DOCKER_GID=0
 
 DDBJ_VALIDATOR_LOG_ANALYSIS_POSTGRES_CONTAINER_NAME=ddbj_validator_log_analysis_postgres
 DDBJ_VALIDATOR_LOG_ANALYSIS_POSTGRES_PORT=18832
-DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_LOGS_DIR=/data1/w3sabi/DDBJValidator/ddbj_validator_staging1/logs
-DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_SHARED_DIR=/data1/w3sabi/DDBJValidator/ddbj_validator_staging1/shared
+# 親 validator app の deploy 配下を /rails にマウントする (RAILS の Rails.root と同じ)。
 DDBJ_VALIDATOR_LOG_ANALYSIS_RUBY_VALIDATOR_DIR=/data1/w3sabi/DDBJValidator/ddbj_validator_staging1


### PR DESCRIPTION
## Summary

The cron-driven `log_analysis` container used to mount three separate host directories under `/usr/src/ddbj_validator/{logs,shared,...}` plus `\${PWD}:/usr/src/log_analysis`. PR #217 changed `create_log_pg.rb` from

```ruby
require File.expand_path('/usr/src/ddbj_validator/lib/validator/common/xml_convertor.rb', __FILE__)
```

to

```ruby
require_relative '../app/models/xml_convertor'
```

…which silently broke at runtime. Inside the container, the script's `__dir__` was `/usr/src/log_analysis`, **not adjacent** to the validator app's `/usr/src/ddbj_validator/app/models/`, so the relative `../app/models/...` resolved to `/usr/src/app/models/...` (nothing there).

Switch to the `/rails` convention used by the main app:

- Replace the three bind mounts with one umbrella mount `\${VALIDATOR_DIR}:/rails`.
- `working_dir: /rails/log_analysis` so `require_relative '../app/models/...'` resolves to `/rails/app/models/xml_convertor` — the same layout as on disk.
- `create_log_pg.rb`: `ACCESS_LOG_DIR` / `LOG_DIR` / `TSV_DIR` move from `/usr/src/ddbj_validator/...` to `/rails/...`.
- `Dockerfile`: drop the `mkdir -p /usr/src/ddbj_validator/...` placeholders and the `COPY ./create_log_pg.rb` (the umbrella bind mount provides it). Only `Gemfile` / `Gemfile.lock` get baked in for `bundle install` at build.
- `postgres` service mounts `\${VALIDATOR_DIR}/logs:/rails/logs` so the docker-exec'd `psql` can `\COPY ... FROM '/rails/logs/tsv/...'`.
- `template.env` drops the now-redundant `RUBY_LOGS_DIR` / `RUBY_SHARED_DIR` keys, leaving `RUBY_VALIDATOR_DIR` as the single host-side knob.

## Operational follow-up

Each instance's `log_analysis/.env` (e.g. `/data1/.../ddbj_validator_staging1/log_analysis/.env`) should drop the now-unused `_RUBY_LOGS_DIR` / `_RUBY_SHARED_DIR` keys.  `_RUBY_VALIDATOR_DIR` keeps its existing value (the validator instance's deploy dir).

## Test plan

- The container itself isn't exercised by the Rails test suite, but to catch any cross-cutting regression: `bin/rails test` (321 runs / 0 failures), `bin/rubocop` (clean), `bin/brakeman` (clean).
- Production verification: next nightly cron run on staging1; if `\COPY` succeeds and `tbl_status` gets a fresh row, the path migration is good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)