### PR TITLE
README: rewrite around current dev / prod workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,100 @@
 # ddbj_validator
-DDBJ Validator is a tool for checking the format and violations of data submission files to DDBJ. Currently, only BioSample/BioProject is supported, but DRA/Trad/JVar will be supported in the future.
 
-## Requirement
-* docker and docker-compose
+DDBJ Validator is a Rails 8 API that checks DDBJ submission files (BioSample / BioProject / DRA / Trad / JVar / MetaboBank) against the project's rule set.
 
-## Install
-```
-$ git clone https://github.com/ddbj/ddbj_validator.git
-$ cd ddbj_validator
-```
+## Stack
 
-## Prepare
-### Download db file
-If you prepare SPARQL endpoint as a container on your host, download the latest database file.  
-If a SPARQL endpoint is provided separately, you do not need to do this, just modify the value of the environment variable `VIRTUOSO_ENDPOINT_MASTER`.
-```
-$ curl -Lo "./shared/data/virtuoso/virtuoso.db" "http://ddbj.nig.ac.jp/ontologies/virtuoso.db"
-```
-### Download coll_dump.txt
-```
-$ mkdir -p conf/coll_dump
-$ curl -o conf/coll_dump/coll_dump.txt "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/coll_dump.txt"
-```
-
-### Download pub repository
-```
-$ git clone https://github.com/ddbj/pub.git conf/pub
-```
-
-## Start containers
-`RAILS_ENV` (`development` / `staging` / `production`) and `RAILS_MASTER_KEY` (decrypts `config/credentials/<env>.yml.enc`) must be present in the environment for the staging/production sections of `config/validator.yml`. Everything else has a sensible default in `compose.yaml`.
-
-```
-$ RAILS_ENV=production RAILS_MASTER_KEY=... podman-compose up -d
-```
-
-## How to use
-Specify a file to validate and POST it to the port specified by `APP_PORT` (default: 18840). The response includes the uuid.
-```
-$ curl -F "biosample=@test/data/biosample/105_taxonomy_warning_ng.xml" "http://localhost:18840/api/validation"
-{"uuid":"17521682-5890-4acc-ad5d-15891ea3c46e","status":"accepted","start_time":"2021-06-08 20:40:58 +0900"}
-```
-Then poll the uuid:
-```
-$ curl "http://localhost:18840/api/validation/17521682-5890-4acc-ad5d-15891ea3c46e"
-```
-See also:
-* http://localhost:18840/api/apispec/index.html
-* https://github.com/ddbj/ddbj_validator/wiki/ValidationAPI%E4%BB%95%E6%A7%98
-
-### From Web app
-```
-http://localhost:18840/api/client/index
-```
-
-## Environment Variables
-
-Read by `compose.yaml`:
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `RAILS_ENV` | — | Rails environment (`development` / `staging` / `production`). |
-| `RAILS_MASTER_KEY` | — | Decrypts `config/credentials/<env>.yml.enc` for staging/production. |
-| `APP_PORT` | `18840` | Host port mapped to the app container. |
-| `SHARED_HOST_DIR` | `./shared` | Host directory mounted at `/rails/shared` (validation results, etc.). |
-| `VIRTUOSO_PORT` | `18841` | Host port mapped to the Virtuoso container. |
-
-Read by `config/validator.yml` in development only (staging / production hardcode these or pull them from credentials):
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `VIRTUOSO_ENDPOINT_MASTER` | `http://localhost:8890/sparql` | SPARQL endpoint URL. |
-| `PGHOST` | `localhost` | DDBJ PostgreSQL host. |
-| `PGPORT` | `5432` | DDBJ PostgreSQL port. |
-| `PGUSER` | `validator` | DDBJ PostgreSQL user. |
-| `PGPASSWORD` | `validator` | DDBJ PostgreSQL password. |
+- Rails 8.1 (API-only) + Puma + Thruster
+- Virtuoso SPARQL endpoint (taxonomy / package metadata)
+- PostgreSQL on the DDBJ central DB (read-only, used by some rules)
+- Sentry for exception reporting
 
 ## Development
-### Unit test
+
+### Prerequisites
+
+- Ruby 4.0.3 (see `.ruby-version`)
+- podman (or docker) to run `compose.test.yaml`, which provides Virtuoso + PostgreSQL with fixtures
+
+### Setup
+
+```sh
+git clone https://github.com/ddbj/ddbj_validator.git
+cd ddbj_validator
+bundle install
+docker compose -f compose.test.yaml up -d
+docker compose -f compose.test.yaml exec virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
 ```
-$ bin/rails test
+
+### Running the server
+
+```sh
+bin/rails server
 ```
+
+Posts go to `http://localhost:3000/api/validation`. `config/validator.yml`'s `development` section reads the standard libpq vars (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`) and `VIRTUOSO_ENDPOINT_MASTER`, all with sensible defaults that match `compose.test.yaml`.
+
+### Tests
+
+```sh
+bin/rails test
+```
+
+PostgreSQL (port 15432) and Virtuoso (port 8890) from `compose.test.yaml` are required — there is no skip path. The suite runs in parallel (`workers: :number_of_processors`).
+
+### Lint / security scan
+
+```sh
+bin/rubocop
+bin/brakeman
+```
+
+Both run in CI alongside the test job.
+
+## API
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/validation` | Submit one or more files, returns `uuid` |
+| `GET`  | `/api/validation/:uuid` | Final result |
+| `GET`  | `/api/validation/:uuid/status` | Progress |
+| `GET`  | `/api/validation/:uuid/:filetype` | Original uploaded file |
+| `GET`  | `/api/validation/:uuid/:filetype/autocorrect` | Auto-annotated file |
+| `GET`  | `/api/package_list`, `/api/attribute_list`, … | BioSample package / attribute metadata |
+
+Spec: <http://localhost:3000/api/apispec/index.html> · [wiki](https://github.com/ddbj/ddbj_validator/wiki/ValidationAPI%E4%BB%95%E6%A7%98)
+Web client: <http://localhost:3000/api/client/index>
+
+Example:
+
+```sh
+curl -F 'biosample=@test/data/biosample/105_taxonomy_warning_ng.xml' http://localhost:3000/api/validation
+# {"uuid":"17521682-...","status":"accepted","start_time":"..."}
+curl http://localhost:3000/api/validation/17521682-...
+```
+
+## Production / staging deployment
+
+Deployment is driven by `bin/deploy <env>` (which rsyncs to each instance directory under `/data1/w3sabi/DDBJValidator/` on the deploy host) and `bin/deploy-remote.sh` (which rebuilds the app image, restarts the container with `podman-compose`, and probes `/api/monitoring`). Each environment hosts up to two instances (`staging1`/`staging2`, `production1`/`production2`); they share `compose.yaml` but have separate per-instance `.env` files.
+
+### Required env vars (`.env` per instance)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RAILS_ENV` | — | `staging` or `production` |
+| `RAILS_MASTER_KEY` | — | Decrypts `config/credentials/<env>.yml.enc` (PG password, Sentry DSN) |
+| `APP_PORT` | `18840` | Host port mapped to the app container; `bin/deploy-remote.sh` uses it for the `/api/monitoring` probe |
+| `SHARED_HOST_DIR` | `./shared` | Host directory mounted at `/rails/shared` |
+| `VIRTUOSO_PORT` | `18841` | Host port mapped to the Virtuoso container |
+
+DDBJ DB hostname/port/user, Virtuoso endpoint, and the named graph URI are hardcoded per environment in `config/validator.yml`. Edit secrets with:
+
+```sh
+bin/rails credentials:edit --environment <env>
+```
+
+### Logs / monitoring
+
+- Application logs go to STDOUT via `ActiveSupport::TaggedLogging.logger(STDOUT)`; `podman logs <app>` is the operator's tail.
+- Unhandled exceptions reach Sentry through `ApplicationController#rescue_from` → `Rails.error.report` (sentry-rails subscribes to the Rails error reporter).
+- `/api/monitoring` runs a full BioSample validation cycle end-to-end and returns 503 if anything in the pipeline is unhealthy.


### PR DESCRIPTION
## Summary

Rewrite the README to match how the project is actually used today.

- **Dev / test no longer touches `compose.yaml`.** The dev section now points at `compose.test.yaml` (which ships PG + Virtuoso with fixtures) and `bin/rails server` directly. The dev port becomes `3000` (Rails default).
- **Drop the obsolete Prepare section.** Downloading `virtuoso.db`, cloning `pub`, and fetching `coll_dump.txt` are no longer relevant: production `compose.yaml` bind-mounts those paths from shared filesystem, and the test stack ships fixtures.
- **Add a Production / staging deployment section** describing `bin/deploy` → `bin/deploy-remote.sh`, the per-instance `.env` knobs that actually exist, and what `config/validator.yml` hardcodes vs. what's in credentials.
- **Add a Logs / monitoring summary** — STDOUT via `ActiveSupport::TaggedLogging`, Sentry via `Rails.error.report` (per PR #232), `/api/monitoring` probe.
- API surface gets a quick table.

Diff: +92 / -75.

## Test plan

README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)