### PR TITLE
Drop dead .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,7 @@
 *.iml
 .idea/
-idea/*
-memo/*
-memo/
-db_conf/*
-db_conf
 tmp/
-memo
-node_modules/*
-*_test_.*
 .DS_Store
-*_back_*
 vendor
 logs
 .bundle
@@ -20,7 +11,6 @@ logs
 deploy_tools/log
 conf/coll_dump
 conf/pub
-data/
 
 !.gitkeep
 
@@ -36,9 +26,5 @@ data_updater/dbfile
 # Rails
 /log/*
 !/log/.keep
-/storage/*
-!/storage/.keep
 /config/master.key
 /config/credentials/*.key
-.byebug_history
-


### PR DESCRIPTION
## Summary

Trim 14 lines from `.gitignore` that no longer match anything in the repo or that target features the project doesn't use.

| Entry | Reason |
|---|---|
| `idea/*` | Typo of `.idea/*` and redundant — `.idea/` already covers it |
| `memo/*`, `memo/`, `memo` | Three duplicate entries for a `memo/` dir that doesn't exist |
| `db_conf/*`, `db_conf` | No `db_conf/` dir anywhere in the tree |
| `node_modules/*` | No JS in this app |
| `*_test_.*`, `*_back_*` | Defensive wildcards that have never matched anything |
| `data/` | No top-level `data/` dir (test data lives under `test/data/`) |
| `/storage/*`, `!/storage/.keep` | Rails ActiveStorage scaffold; we don't use ActiveStorage and there's no `storage/` dir |
| `.byebug_history` | `byebug` isn't in the Gemfile |

## Test plan

- [x] `bin/rails test` (321 runs, 2638 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)