### PR TITLE
Drop bin/deploy_tools/update_validator_dbfile_const.sh

### DIFF
--- a/bin/deploy_tools/update_validator_dbfile_const.sh
+++ b/bin/deploy_tools/update_validator_dbfile_const.sh
@@ -1,7 +1,0 @@
-BASE_DIR=/data1/w3sabi/DDBJValidator/ddbj_validator_const
-VIRTUOSO_CONTAINER_NAME=ddbj_validator_virtuoso_const
-VIRT_PORT=18841
-VIRT_HOME=$BASE_DIR/shared/data/virtuoso/
-
-ROOT_DIR=$(cd $(dirname $0); pwd)
-. $ROOT_DIR/update_validator_dbfile


### PR DESCRIPTION
## Summary

Delete `bin/deploy_tools/update_validator_dbfile_const.sh`. The `_const` instance and `ddbj_validator_virtuoso_const` container it targeted are not part of the current deployment topology (only `staging1`, `staging2`, `production1`, `production2` are live, each with its own per-instance `update_validator_dbfile_*.sh`).

## Test plan

- [x] `bin/rails test` (321 runs, 2638 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)