### PR TITLE
Wire bin/dev to compose.dev.yaml via foreman (rename compose.test.yaml)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           bundler-cache: true
 
       - name: Start Virtuoso & Postgres with fixtures
-        run: docker compose -f compose.test.yaml up -d
+        run: docker compose -f compose.dev.yaml up -d
 
       - name: Wait for Virtuoso to accept SPARQL
         run: |
@@ -64,11 +64,11 @@ jobs:
             sleep 2
           done
           echo 'Postgres did not become ready' >&2
-          docker compose -f compose.test.yaml logs postgres | tail -40 >&2
+          docker compose -f compose.dev.yaml logs postgres | tail -40 >&2
           exit 1
 
       - name: Load taxonomy / biosample fixture
-        run: docker compose -f compose.test.yaml exec -T virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
+        run: docker compose -f compose.dev.yaml exec -T virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
 
       # -v で各テスト名を標準出力に流す。どのテストで詰まったかを CI ログから特定できるように
       # pub / coll_dump は test/test_helpers.rb が env 経由で test/fixtures を指すので、

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web:     bin/rails server -p 3000
+compose: docker compose -f compose.dev.yaml up

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DDBJ Validator is a Rails 8 API that checks DDBJ submission files (BioSample / B
 ### Prerequisites
 
 - Ruby 4.0.3 (see `.ruby-version`)
-- podman (or docker) to run `compose.test.yaml`, which provides Virtuoso + PostgreSQL with fixtures
+- podman (or docker) to run `compose.dev.yaml`, which provides Virtuoso + PostgreSQL with fixtures
 
 ### Setup
 
@@ -22,17 +22,20 @@ DDBJ Validator is a Rails 8 API that checks DDBJ submission files (BioSample / B
 git clone https://github.com/ddbj/ddbj_validator.git
 cd ddbj_validator
 bundle install
-docker compose -f compose.test.yaml up -d
-docker compose -f compose.test.yaml exec virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
+docker compose -f compose.dev.yaml up -d
+docker compose -f compose.dev.yaml exec virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
+docker compose -f compose.dev.yaml down
 ```
+
+The Virtuoso `LOAD` step is one-time (the fixture data persists in the container's volume). After that, `bin/dev` brings everything up together.
 
 ### Running the server
 
 ```sh
-bin/rails server
+bin/dev
 ```
 
-Posts go to `http://localhost:3000/api/validation`. `config/validator.yml`'s `development` section reads the standard libpq vars (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`) and `VIRTUOSO_ENDPOINT_MASTER`, all with sensible defaults that match `compose.test.yaml`.
+`bin/dev` runs `Procfile.dev` via foreman: the Rails server on `:3000` plus `compose.dev.yaml` (Virtuoso + Postgres) in the foreground. Stop with Ctrl-C and both processes shut down. `config/validator.yml`'s `development` section reads the standard libpq vars (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`) and `VIRTUOSO_ENDPOINT_MASTER`, all with defaults that match `compose.dev.yaml`.
 
 ### Tests
 
@@ -40,7 +43,7 @@ Posts go to `http://localhost:3000/api/validation`. `config/validator.yml`'s `de
 bin/rails test
 ```
 
-PostgreSQL (port 15432) and Virtuoso (port 8890) from `compose.test.yaml` are required — there is no skip path. The suite runs in parallel (`workers: :number_of_processors`).
+PostgreSQL (port 15432) and Virtuoso (port 8890) from `compose.dev.yaml` are required — there is no skip path. Run `bin/dev` (or `docker compose -f compose.dev.yaml up -d`) first. The suite runs in parallel (`workers: :number_of_processors`).
 
 ### Lint / security scan
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,7 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env bash
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -2,8 +2,8 @@
 # 本番用 compose.yaml とは別の volume / graph で動く。
 #
 # 使い方:
-#   docker compose -f compose.test.yaml up -d
-#   docker compose -f compose.test.yaml exec virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
+#   docker compose -f compose.dev.yaml up -d
+#   docker compose -f compose.dev.yaml exec virtuoso isql -U dba -P dba exec='LOAD /fixtures/load.sql;'
 #   bin/rails test    # or  bin/rails server
 services:
   virtuoso:

--- a/config/validator.yml
+++ b/config/validator.yml
@@ -27,7 +27,7 @@ development: &dev
 
 test:
   <<: *dev
-  # compose.test.yaml で立ち上がる Virtuoso / Postgres を必ず指す。
+  # compose.dev.yaml で立ち上がる Virtuoso / Postgres を必ず指す。
   # Postgres は dev と port が衝突しないよう 15432 にずらしてある。
   sparql_endpoint:
     master_endpoint: http://localhost:8890/sparql


### PR DESCRIPTION
## Summary

- Replace the stub `bin/dev` (just `exec bin/rails server`) with foreman driving a new `Procfile.dev`:

  ```
  web:     bin/rails server -p 3000
  compose: docker compose -f compose.dev.yaml up
  ```

  Single command brings up the local stack; single Ctrl-C tears it down. `-p 3000` keeps Puma off foreman's default `PORT=5000`. `bin/dev` auto-installs the `foreman` gem on first run if it's missing.

- Rename `compose.test.yaml` → `compose.dev.yaml` since the stack is now the canonical dev backing service. Tests and CI still use the same file under the new name.

- Update all references: `Procfile.dev`, `README.md`, `.github/workflows/test.yml`, `config/validator.yml`, and the internal header comment.

## Why

- `bin/dev` is the Rails-canonical "one command to start dev" entry point. Aligning with that convention reduces onboarding friction and keeps `bin/rails test` from silently failing because someone forgot to bring the compose stack up first.
- "test.yaml" misrepresented the file once it became the dev backing service too. "dev.yaml" matches the primary use case.

## Test plan

- [x] `bin/rails test` (321 runs, 2638 assertions, 0 failures, 0 errors, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)